### PR TITLE
Update dataset example

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,7 +188,7 @@ vdf = vDataFrame("my_relation", cursor = cur)
 ```
 If you don't have data on hand, you can easily import well-known datasets.
 ```python
-from verticapy.learn.datasets import load_titanic
+from verticapy.datasets import load_titanic
 vdf = load_titanic(cursor = cur)
 ```
 Examine your data:


### PR DESCRIPTION
Update the dataset example to reference `verticapy.datasets` instead of `verticapy.learn.datasets` which throws a `ModuleNotFoundError`