### PR TITLE
Fix connection backup_server_node parameter

### DIFF
--- a/verticapy/connect.py
+++ b/verticapy/connect.py
@@ -413,7 +413,7 @@ dict
 
             elif option_name == "backup_server_node":
                 backup_server_node = {}
-                exec(f"id_port = {option_val}", {}, backup_server_node)
+                exec(f"id_port = '{option_val}'", {}, backup_server_node)
                 conn_info["backup_server_node"] = backup_server_node["id_port"]
 
             elif option_name == "kerberosservicename":


### PR DESCRIPTION
This fixes a SyntaxError with the backup_server_node setting. The code attempts to execute: id_port = 11.111.111.1 when the desired functionality is id_port = '11.111.111.1'.