### PR TITLE
Update vDataFrame interactiveness

### DIFF
--- a/verticapy/html/html_template_connected.html
+++ b/verticapy/html/html_template_connected.html
@@ -12,6 +12,7 @@
 
     // Define the dt_args
     let dt_args = {
+            language: {"info": "<b>Showing rows:</b> _START_ to _END_"},
             scrollY: 300,
             scrollX: true,
             scrollCollapse: true,

--- a/verticapy/html/style.css
+++ b/verticapy/html/style.css
@@ -2,6 +2,9 @@ table td {
     text-overflow: ellipsis;
     overflow: hidden;
     text-align: center !important;
+    background-color: #FAFAFA;
+}
+table tr:nth-child(1)  {
     background-color: #FFFFFF;
 }
 
@@ -29,3 +32,6 @@ thead input {
     box-sizing: border-box;
 }
 
+table thead tr td {
+    background-color: #FFFFFF;
+  }

--- a/verticapy/javascript.py
+++ b/verticapy/javascript.py
@@ -153,7 +153,7 @@ def datatables_repr(
     data = clean_data(data)
     output = read_package_file("html/html_template_connected.html")
     style = "width:100%"
-    classes = ["display"]
+    classes = ["hover", "row-border"]
     if isinstance(classes, list):
         classes = " ".join(classes)
     tableId = str(uuid.uuid4())


### PR DESCRIPTION
This updates the interactive mode by:
- keeping the index white
- The footer was confusing so I made a simple message that just tells the range of rows that are currently being displayed.

Here is an example of a table:
![image](https://user-images.githubusercontent.com/55731470/194777280-41418c46-d699-4a1d-9879-d2b498c617bb.png)

Closes: #354