### PR TITLE
Adding complex datatype parameter for read_json

### DIFF
--- a/verticapy/utilities.py
+++ b/verticapy/utilities.py
@@ -2068,7 +2068,7 @@ read_csv : Ingests a CSV file into the Vertica database.
             all_files = os.listdir(dirname)
             max_files=sum(1 for x in all_files if x.endswith(".json"))
         else:
-            max_files=100
+            max_files=1000
         return read_file(
         path=path,
         schema=schema,


### PR DESCRIPTION
@oualib Please check it out. 

Currently, we cannot search for number of files in the server so wildcard search for number of files ONLY works for local. But currently infer DDL does not work for local so counting max files is essentially useless. but I have put it anyway for future. 

close #397 