### PR TITLE
Support of many DBLINK calls

### DIFF
--- a/verticapy/toolbox.py
+++ b/verticapy/toolbox.py
@@ -1173,9 +1173,10 @@ def replace_external_queries_in_query(query: str):
         "alter ",
         "update ",
     )
+    nb_external_queries = 0
     for s in verticapy.options["external_connection"]:
         external_queries = re.findall(f"\\{s}\\{s}\\{s}(.*?)\\{s}\\{s}\\{s}", query)
-        for idx, external_query in enumerate(external_queries):
+        for external_query in external_queries:
             if external_query.strip().lower().startswith(sql_keyword):
                 external_query_tmp = external_query
                 subquery_flag = False
@@ -1183,15 +1184,24 @@ def replace_external_queries_in_query(query: str):
                 external_query_tmp = f"SELECT * FROM {external_query}"
                 subquery_flag = True
             query_dblink_template = get_dblink_fun(external_query_tmp, symbol=s)
-            if subquery_flag:
-                if " " in external_query.strip():
-                    alias = f"VERTICAPY_EXTERNAL_TABLE_{idx}"
-                else:
-                    alias = '"' + external_query.strip().replace('"', '""') + '"'
-                query_dblink_template = f"({query_dblink_template}) AS {alias}"
+            if " " in external_query.strip():
+                alias = f"VERTICAPY_EXTERNAL_TABLE_{nb_external_queries}"
+            else:
+                alias = '"' + external_query.strip().replace('"', '""') + '"'
+            if nb_external_queries > 1:
+                temp_table_name = gen_tmp_name(name=alias)
+                create_statement = f"CREATE LOCAL TEMPORARY TABLE {temp_table_name} ON COMMIT PRESERVE ROWS AS {query_dblink_template}"
+                executeSQL(
+                    create_statement, title=f"Creating a temporary local table to store the {nb_external_queries} external table.",
+                )
+                query_dblink_template = f"v_temp_schema.{temp_table_name} AS {alias}"
+            else:
+                if subquery_flag:
+                    query_dblink_template = f"({query_dblink_template}) AS {alias}"
             query = query.replace(
                 f"{s}{s}{s}{external_query}{s}{s}{s}", query_dblink_template
             )
+            nb_external_queries += 1
     return query
 
 

--- a/verticapy/toolbox.py
+++ b/verticapy/toolbox.py
@@ -1188,11 +1188,12 @@ def replace_external_queries_in_query(query: str):
                 alias = f"VERTICAPY_EXTERNAL_TABLE_{nb_external_queries}"
             else:
                 alias = '"' + external_query.strip().replace('"', '""') + '"'
-            if nb_external_queries > 1:
-                temp_table_name = gen_tmp_name(name=alias)
+            if nb_external_queries >= 1:
+                temp_table_name = '"' + gen_tmp_name(name=alias).replace('"', '') + '"'
                 create_statement = f"CREATE LOCAL TEMPORARY TABLE {temp_table_name} ON COMMIT PRESERVE ROWS AS {query_dblink_template}"
                 executeSQL(
-                    create_statement, title=f"Creating a temporary local table to store the {nb_external_queries} external table.",
+                    create_statement,
+                    title=f"Creating a temporary local table to store the {nb_external_queries} external table.",
                 )
                 query_dblink_template = f"v_temp_schema.{temp_table_name} AS {alias}"
             else:

--- a/verticapy/utilities.py
+++ b/verticapy/utilities.py
@@ -2591,11 +2591,14 @@ def readSQL(query: str, time_on: bool = False, limit: int = 100):
     )
     while len(query) > 0 and query[-1] in (";", " "):
         query = query[:-1]
-    count = executeSQL(
-        f"SELECT /*+LABEL('utilities.readSQL')*/ COUNT(*) FROM ({query}) VERTICAPY_SUBTABLE",
-        method="fetchfirstelem",
-        print_time_sql=False,
-    )
+    if verticapy.options["count_on"]:
+        count = executeSQL(
+            f"SELECT /*+LABEL('utilities.readSQL')*/ COUNT(*) FROM ({query}) VERTICAPY_SUBTABLE",
+            method="fetchfirstelem",
+            print_time_sql=False,
+        )
+    else:
+        count = -1
     sql_on_init = verticapy.options["sql_on"]
     time_on_init = verticapy.options["time_on"]
     try:


### PR DESCRIPTION
 - We use temp local table when there is many DBLINK calls.
 - It finalises the DBLINK integration.