### PR TITLE
Classification Metrics: Parameters Normalization

### DIFF
--- a/verticapy/_utils/_sql/_vertica_version.py
+++ b/verticapy/_utils/_sql/_vertica_version.py
@@ -49,7 +49,6 @@ MINIMUM_VERTICA_VERSION = {
     "KPrototypes": [12, 0, 3],
     "MCA": [9, 1, 0],
     "MinMaxScaler": [8, 1, 0],
-    "multilabel_confusion_matrix": [8, 0, 0],
     "MultinomialNB": [8, 0, 0],
     "NaiveBayes": [8, 0, 0],
     "OneHotEncoder": [9, 0, 0],

--- a/verticapy/learn/metrics/__init__.py
+++ b/verticapy/learn/metrics/__init__.py
@@ -25,7 +25,6 @@ from verticapy.machine_learning.metrics.classification import (
     log_loss,
     markedness,
     matthews_corrcoef,
-    multilabel_confusion_matrix,
     negative_predictive_score,
     prc_auc,
     roc_auc,

--- a/verticapy/machine_learning/metrics/__init__.py
+++ b/verticapy/machine_learning/metrics/__init__.py
@@ -32,7 +32,6 @@ from verticapy.machine_learning.metrics.classification import (
     log_loss,
     markedness,
     matthews_corrcoef,
-    multilabel_confusion_matrix,
     negative_predictive_score,
     negative_likelihood_ratio,
     positive_likelihood_ratio,

--- a/verticapy/machine_learning/model_selection/hp_tuning/cv.py
+++ b/verticapy/machine_learning/model_selection/hp_tuning/cv.py
@@ -57,7 +57,7 @@ def randomized_search_cv(
     y: str,
     metric: str = "auto",
     cv: int = 3,
-    average: Literal["micro", "macro", "weighted", "scores"] = "weighted",
+    average: Literal[None, "micro", "macro", "weighted"] = "weighted",
     pos_label: Optional[PythonScalar] = None,
     cutoff: float = -1,
     nbins: int = 1000,
@@ -142,6 +142,7 @@ def randomized_search_cv(
                        class.
             weighted : weighted average of the score of 
                        each class.
+            None     : scores  for   all  the  classes.
     pos_label: PythonScalar, optional
         The main class to be considered as positive 
         (classification only).
@@ -202,7 +203,7 @@ def grid_search_cv(
     y: str,
     metric: str = "auto",
     cv: int = 3,
-    average: Literal["micro", "macro", "weighted", "scores"] = "weighted",
+    average: Literal[None, "micro", "macro", "weighted"] = "weighted",
     pos_label: Optional[PythonScalar] = None,
     cutoff: PythonNumber = -1,
     training_score: bool = True,
@@ -289,6 +290,7 @@ def grid_search_cv(
                        class.
             weighted : weighted average of the score of 
                        each class.
+            None     : scores  for   all  the  classes.
     pos_label: PythonScalar, optional
         The main class to  be considered as positive 
         (classification only).

--- a/verticapy/machine_learning/model_selection/hp_tuning/plotting.py
+++ b/verticapy/machine_learning/model_selection/hp_tuning/plotting.py
@@ -46,7 +46,7 @@ def validation_curve(
     y: str,
     metric: str = "auto",
     cv: int = 3,
-    average: Literal["micro", "macro", "weighted", "scores"] = "weighted",
+    average: Literal[None, "micro", "macro", "weighted"] = "weighted",
     pos_label: Optional[PythonScalar] = None,
     cutoff: float = -1,
     std_coeff: float = 1,
@@ -133,6 +133,7 @@ def validation_curve(
                        class.
             weighted : weighted average of the score of 
                        each class.
+            None     : scores  for   all  the  classes.
     pos_label: PythonScalar, optional
         The main class to be considered as positive 
         (classification only).

--- a/verticapy/machine_learning/model_selection/model_validation.py
+++ b/verticapy/machine_learning/model_selection/model_validation.py
@@ -52,7 +52,7 @@ def cross_validate(
     y: str,
     metrics: Union[None, str, list[str]] = None,
     cv: int = 3,
-    average: Literal["micro", "macro", "weighted", "scores"] = "weighted",
+    average: Literal[None, "micro", "macro", "weighted"] = "weighted",
     pos_label: Optional[PythonScalar] = None,
     cutoff: PythonNumber = -1,
     show_time: bool = True,
@@ -144,6 +144,7 @@ def cross_validate(
                            class.
                 weighted : weighted average of the score of 
                            each class.
+                None     : scores  for   all  the  classes.
     pos_label: PythonScalar, optional
     	The main class to be considered as positive 
         (classification only).
@@ -283,7 +284,7 @@ def learning_curve(
     method: Literal["efficiency", "performance", "scalability"] = "efficiency",
     metric: str = "auto",
     cv: int = 3,
-    average: Literal["micro", "macro", "weighted", "scores"] = "weighted",
+    average: Literal[None, "micro", "macro", "weighted"] = "weighted",
     pos_label: Optional[PythonScalar] = None,
     cutoff: PythonNumber = -1,
     std_coeff: PythonNumber = 1,
@@ -378,6 +379,7 @@ def learning_curve(
                        class.
             weighted : weighted average of the score of 
                        each class.
+            None     : scores  for   all  the  classes.
     pos_label: PythonScalar, optional
         The main class to be considered as positive 
         (classification only).

--- a/verticapy/machine_learning/model_selection/variables_selection.py
+++ b/verticapy/machine_learning/model_selection/variables_selection.py
@@ -55,7 +55,7 @@ def randomized_features_search_cv(
     y: str,
     metric: str = "auto",
     cv: int = 3,
-    average: Literal["micro", "macro", "weighted", "scores"] = "weighted",
+    average: Literal[None, "micro", "macro", "weighted"] = "weighted",
     pos_label: Optional[PythonScalar] = None,
     cutoff: PythonNumber = -1,
     training_score: bool = True,
@@ -142,6 +142,7 @@ def randomized_features_search_cv(
                        class.
             weighted : weighted average of the score of 
                        each class.
+            None     : scores  for   all  the  classes.
     pos_label: PythonScalar, optional
         The main class to be  considered as positive 
         (classification only).

--- a/verticapy/machine_learning/vertica/base.py
+++ b/verticapy/machine_learning/vertica/base.py
@@ -1996,7 +1996,7 @@ class MulticlassClassifier(Supervised):
             return self._confusion_matrix(pos_label=pos_label, cutoff=cutoff,)
         elif isinstance(pos_label, NoneType):
             return mt.confusion_matrix(
-                self.y, self.deploySQL(), self.test_relation, classes=self.classes_
+                self.y, self.deploySQL(), self.test_relation, labels=self.classes_
             )
         else:
             pos_label = self._check_pos_label(pos_label=pos_label)

--- a/verticapy/machine_learning/vertica/base.py
+++ b/verticapy/machine_learning/vertica/base.py
@@ -1995,8 +1995,8 @@ class MulticlassClassifier(Supervised):
         if hasattr(self, "_confusion_matrix"):
             return self._confusion_matrix(pos_label=pos_label, cutoff=cutoff,)
         elif isinstance(pos_label, NoneType):
-            return mt.multilabel_confusion_matrix(
-                self.y, self.deploySQL(), self.test_relation, self.classes_
+            return mt.confusion_matrix(
+                self.y, self.deploySQL(), self.test_relation, classes=self.classes_
             )
         else:
             pos_label = self._check_pos_label(pos_label=pos_label)
@@ -2012,7 +2012,7 @@ class MulticlassClassifier(Supervised):
     def score(
         self,
         metric: Literal[tuple(mt.FUNCTIONS_CLASSIFICATION_DICTIONNARY)] = "accuracy",
-        average: Literal["micro", "macro", "weighted", "scores"] = "weighted",
+        average: Literal[None, "micro", "macro", "weighted"] = "weighted",
         pos_label: Optional[PythonScalar] = None,
         cutoff: PythonNumber = 0.5,
         nbins: int = 10000,
@@ -2069,7 +2069,7 @@ class MulticlassClassifier(Supervised):
                            class.
                 weighted : weighted average of the score of 
                            each class.
-                scores   : scores  for   all  the  classes.
+                None     : scores  for   all  the  classes.
         pos_label: PythonScalar, optional
             Label  to  consider   as  positive.  All the 
             other classes will be  merged and considered 

--- a/verticapy/machine_learning/vertica/neighbors.py
+++ b/verticapy/machine_learning/vertica/neighbors.py
@@ -523,8 +523,8 @@ class KNeighborsClassifier(MulticlassClassifier):
                     ROW_NUMBER() OVER(PARTITION BY {", ".join(self.X)}, row_id 
                                       ORDER BY proba_predict DESC) AS pos 
                  FROM {self.deploySQL()}) neighbors_table WHERE pos = 1"""
-            return mt.multilabel_confusion_matrix(
-                self.y, "predict_neighbors", input_relation, self.classes_
+            return mt.confusion_matrix(
+                self.y, "predict_neighbors", input_relation, classes=self.classes_
             )
         else:
             cutoff = self._check_cutoff(cutoff=cutoff)


### PR DESCRIPTION
 - multilabel_confusion_matrix is a wrong name for what it is. We've built one unified confusion_matrix function
 - Parameter scores is replaced to None as the one of sklearn.

TODO:
 - add the binary option.