### PR TITLE
Missing docstrings

### DIFF
--- a/verticapy/core/vdataframe/_multiprocessing.py
+++ b/verticapy/core/vdataframe/_multiprocessing.py
@@ -28,7 +28,7 @@ def aggregate_parallel_block(
     vdf: "vDataFrame", func: list, columns: SQLColumns, ncols_block: int, i: int
 ) -> TableSample:
     """
-    Missing function description?
+    Missing docstring?
     """
     return vdf.aggregate(
         func=func, columns=columns[i : i + ncols_block], ncols_block=ncols_block
@@ -44,7 +44,7 @@ def describe_parallel_block(
     i: int,
 ) -> TableSample:
     """
-    Missing function description?
+    Missing docstring?
     """
     return vdf.describe(
         method=method,

--- a/verticapy/core/vdataframe/_multiprocessing.py
+++ b/verticapy/core/vdataframe/_multiprocessing.py
@@ -28,7 +28,9 @@ def aggregate_parallel_block(
     vdf: "vDataFrame", func: list, columns: SQLColumns, ncols_block: int, i: int
 ) -> TableSample:
     """
-    Missing docstring?
+    Parallelizes the computations of the aggregate vDataFrame
+    method. This allows the vDataFrame to send multiple 
+    queries at the same time.
     """
     return vdf.aggregate(
         func=func, columns=columns[i : i + ncols_block], ncols_block=ncols_block
@@ -44,7 +46,9 @@ def describe_parallel_block(
     i: int,
 ) -> TableSample:
     """
-    Missing docstring?
+    Parallelizes the computations of the describe vDataFrame
+    method. This allows the vDataFrame to send multiple 
+    queries at the same time.
     """
     return vdf.describe(
         method=method,

--- a/verticapy/plotting/_utils.py
+++ b/verticapy/plotting/_utils.py
@@ -67,7 +67,7 @@ class PlottingUtils:
         style_kwargs: Optional[dict] = None,
     ) -> tuple[Literal[vpy_highcharts_plt, vpy_matplotlib_plt, vpy_plotly_plt], dict]:
         """
-        Missing function description?
+        Missing docstring?
         """
         highchart_kwargs, plotly_kwargs, matplotlib_kwargs, style_kwargs = format_type(
             highchart_kwargs, plotly_kwargs, matplotlib_kwargs, style_kwargs, dtype=dict

--- a/verticapy/plotting/_utils.py
+++ b/verticapy/plotting/_utils.py
@@ -67,7 +67,12 @@ class PlottingUtils:
         style_kwargs: Optional[dict] = None,
     ) -> tuple[Literal[vpy_highcharts_plt, vpy_matplotlib_plt, vpy_plotly_plt], dict]:
         """
-        Missing docstring?
+        Returns the first available library (Plotly, Matplotlib, or
+        Highcharts) to draw a specific graphic. If the graphic is not
+        available for a library, function tries the next plotting 
+        library. The style applied to the graphic corresponds to the 
+        input style. The final graphic is drawn using the input
+        'chart' object.
         """
         highchart_kwargs, plotly_kwargs, matplotlib_kwargs, style_kwargs = format_type(
             highchart_kwargs, plotly_kwargs, matplotlib_kwargs, style_kwargs, dtype=dict

--- a/verticapy/plotting/base.py
+++ b/verticapy/plotting/base.py
@@ -235,7 +235,9 @@ class PlottingBase(PlottingBaseSQL):
         self, d: Optional[dict] = None, idx: Optional[int] = None
     ) -> Union[list, str]:
         """
-        Missing docstring?
+        If a color or list of colours is available in the
+        input dictionary, return it. Otherwise, this function
+        returns the current module str or list of colors. 
         """
         d = format_type(d, dtype=dict)
         if "color" in d:

--- a/verticapy/plotting/base.py
+++ b/verticapy/plotting/base.py
@@ -235,7 +235,7 @@ class PlottingBase(PlottingBaseSQL):
         self, d: Optional[dict] = None, idx: Optional[int] = None
     ) -> Union[list, str]:
         """
-        Missing function description?
+        Missing docstring?
         """
         d = format_type(d, dtype=dict)
         if "color" in d:


### PR DESCRIPTION
I marked the functions that might be missing docstrings. Some of these might be internal (so might not be absolutely necessary to add docstrings), but thought it best to identify them just in case. If none of these functions require descriptions, we can just close this PR.