### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 [![PyPI version](https://badge.fury.io/py/verticapy.svg)](https://badge.fury.io/py/verticapy)
 [![Conda Version](https://img.shields.io/conda/vn/conda-forge/verticapy?color=yellowgreen)](https://anaconda.org/conda-forge/verticapy)
 [![License](https://img.shields.io/badge/License-Apache%202.0-orange.svg)](https://opensource.org/licenses/Apache-2.0)
-[![Python Version](https://img.shields.io/pypi/pyversions/verticapy.svg)](https://www.python.org/downloads/)
+[![Python Version](https://img.shields.io/badge/python-3.9%20%7C%203.10%20%7C%203.11-blue)](https://www.python.org/downloads/)
 [![codecov](https://codecov.io/gh/vertica/VerticaPy/branch/master/graph/badge.svg?token=a6GiFYI9at)](https://codecov.io/gh/vertica/VerticaPy)
 
 <p align="center">

--- a/verticapy/tests_new/plotting/plotly/test_plotly_boxplot.py
+++ b/verticapy/tests_new/plotting/plotly/test_plotly_boxplot.py
@@ -121,7 +121,6 @@ class TestPlotlyVDCBoxPlot(VDCBoxPlot):
         ), "median not computed correctly"
 
 
-
 class TestPlotlyParitionVDCBoxPlot(VDCParitionBoxPlot):
     """
     Testing different attributes of Box plot on a vDataColumn using "by" attribute


### PR DESCRIPTION
We currently test our package only with Python versions 3.9, 3.10, and 3.11. Therefore, it makes sense to represent these versions on the badge of the supported Python versions.