### PR TITLE
Bug Fix for 1D Outliers plot using matplotlib

### DIFF
--- a/verticapy/plotting/_matplotlib/outliers.py
+++ b/verticapy/plotting/_matplotlib/outliers.py
@@ -87,7 +87,9 @@ class OutliersPlot(ScatterPlot):
         Z = self.data["map"]["Z"]
         zvals = self.data["map"]["zvals"]
         if len(self.layout["columns"]) == 1:
-            cp = ax.contourf(X, Y, Z, cmap=cmap, levels=np.linspace(th, Z.max(), 8))
+            if Z.max()>th:
+                cp = ax.contourf(X, Y, Z, cmap=cmap, levels=np.linspace(th, Z.max(), 8))
+                fig.colorbar(cp).set_label("ZSCORE")
             ax.fill_between(zvals, [-1, -1], [1, 1], facecolor=self.layout["color"])
             for x0 in zvals:
                 ax.plot([x0, x0], [-1, 1], color=self.layout["inliers_border_color"])
@@ -107,6 +109,7 @@ class OutliersPlot(ScatterPlot):
                 **self.init_style_linewidth,
             )
             cp = ax.contourf(X, Y, Z, cmap=cmap, levels=np.linspace(th, Z.max(), 8))
+            fig.colorbar(cp).set_label("ZSCORE")
             ax.set_xlabel(self.layout["columns"][0])
             ax.set_ylabel(self.layout["columns"][1])
         for x, c in [
@@ -122,7 +125,6 @@ class OutliersPlot(ScatterPlot):
                     **style_kwargs,
                 },
             )
-        fig.colorbar(cp).set_label("ZSCORE")
         args = [[0], [0]]
         ax.legend(
             [

--- a/verticapy/plotting/_matplotlib/outliers.py
+++ b/verticapy/plotting/_matplotlib/outliers.py
@@ -87,7 +87,7 @@ class OutliersPlot(ScatterPlot):
         Z = self.data["map"]["Z"]
         zvals = self.data["map"]["zvals"]
         if len(self.layout["columns"]) == 1:
-            if Z.max()>th:
+            if Z.max() > th:
                 cp = ax.contourf(X, Y, Z, cmap=cmap, levels=np.linspace(th, Z.max(), 8))
                 fig.colorbar(cp).set_label("ZSCORE")
             ax.fill_between(zvals, [-1, -1], [1, 1], facecolor=self.layout["color"])

--- a/verticapy/tests_new/plotting/matplotlib/test_matplotlib_outliers.py
+++ b/verticapy/tests_new/plotting/matplotlib/test_matplotlib_outliers.py
@@ -23,6 +23,7 @@ class TestMatplotlibOutliersPlot(OutliersPlot):
     Testing different attributes of outliers plot on a vDataColumn
     """
 
+
 class TestMatplotlibOutliersPlot2D(OutliersPlot2D):
     """
     Testing different attributes of outliers plot on a vDataFrame

--- a/verticapy/tests_new/plotting/matplotlib/test_matplotlib_outliers.py
+++ b/verticapy/tests_new/plotting/matplotlib/test_matplotlib_outliers.py
@@ -23,27 +23,6 @@ class TestMatplotlibOutliersPlot(OutliersPlot):
     Testing different attributes of outliers plot on a vDataColumn
     """
 
-    def test_data_all_scatter_points_for_1d(
-        self,
-        dummy_dist_vd,
-    ):
-        """
-        Testing to make sure all poitns are plotted
-        """
-        # Arrange
-        total_points = len(dummy_dist_vd[self.COL_NAME_1])
-        # Act
-        result = dummy_dist_vd.outliers_plot(
-            columns=[self.COL_NAME_1], max_nb_points=10000
-        )
-        plot_points_count = sum(
-            len(result.get_children()[i].get_offsets()) for i in range(10, 12)
-        )
-        assert (
-            plot_points_count == total_points
-        ), "All points are not plotted for 1d plot"
-
-
 class TestMatplotlibOutliersPlot2D(OutliersPlot2D):
     """
     Testing different attributes of outliers plot on a vDataFrame


### PR DESCRIPTION
Created an IF condition for the 1D contour plot using matplotlib.
Unless the Z score is larger than the threshold, there will not be any contour plot.

Previously, it was unchecked and created errors because the levels for contours were decreasing. 