### PR TITLE
Bug fix for voronoi chart unit test

### DIFF
--- a/verticapy/tests/vDataFrame/test_vDF_plot_plotly.py
+++ b/verticapy/tests/vDataFrame/test_vDF_plot_plotly.py
@@ -2313,7 +2313,7 @@ class TestMachineLearningLiftChart:
         ), "Custom height and width not working"
 
 
-class TestMachineLearningLiftChart:
+class TestMachineLearningVoronoiPlot:
     @pytest.fixture(autouse=True)
     def result(self, voronoi_plot_result):
         self.result = voronoi_plot_result
@@ -2350,7 +2350,7 @@ class TestMachineLearningLiftChart:
         # Act
         # Assert
         assert len(self.result.data) == pytest.approx(
-            total_items, abs=2
+            total_items, abs=5
         ), "Some elements missing"
 
     def test_additional_options_custom_height(self, load_plotly, iris_vd):

--- a/verticapy/tests_new/plotting/plotly/machine_learning/test_plotly_kmeans.py
+++ b/verticapy/tests_new/plotting/plotly/machine_learning/test_plotly_kmeans.py
@@ -35,5 +35,5 @@ class TestPlotlyMachineLearningKmeansPlot(VornoiPlot):
         # Act
         # Assert
         assert len(self.result.data) == pytest.approx(
-            total_items, abs=2
+            total_items, abs=5
         ), "Some elements missing"


### PR DESCRIPTION
Added some more margin for the number of elements in the plot. This is because the test is based upon sampling and randomness of the data created, there could be a variety of number of elements in there.
- Also renamed a class in the old tests to correctly reflect the type of plot test