### PR TITLE
roc_auc_score for multiclass classification using micro and macro averaging

### DIFF
--- a/verticapy/machine_learning/metrics/classification.py
+++ b/verticapy/machine_learning/metrics/classification.py
@@ -1643,7 +1643,6 @@ def _compute_multiclass_metric(
     y_true: str,
     y_score: Union[str, ArrayLike],
     input_relation: SQLRelation,
-    fun_sql_name: Optional[str],
     average: Literal[None, "binary", "micro", "macro", "scores", "weighted"] = None,
     labels: Optional[ArrayLike] = None,
     nbins: int = 10000,
@@ -1674,7 +1673,12 @@ def _compute_multiclass_metric(
 
 
 def _compute_micro_multiclass_metric(
-    y_true, y_score, input_relation, labels, nbins, fun_sql_name
+    y_true: str,
+    y_score: ArrayLike,
+    input_relation: SQLRelation,
+    labels: ArrayLike,
+    nbins: int,
+    fun_sql_name: Optional[str],
 ):
     if fun_sql_name == "roc":
         X = ["decision_boundary", "false_positive_rate", "true_positive_rate"]
@@ -2068,13 +2072,8 @@ def prc_auc_score(
         for i in range(len(y_score)):
             sorted_pairs = sorted(zip(recall[i], precision[i]))
             recall_sorted, precision_sorted = zip(*sorted_pairs)
-            mean_precision += np.interp(
-                recall_grid, recall_sorted, precision_sorted
-            )  # linear interpolation
-
-        # Average it and compute AUC
+            mean_precision += np.interp(recall_grid, recall_sorted, precision_sorted)
         mean_precision /= len(y_score)
-
         recall_macro = recall_grid
         precision_macro = mean_precision
         prc_auc = _compute_area(

--- a/verticapy/machine_learning/metrics/classification.py
+++ b/verticapy/machine_learning/metrics/classification.py
@@ -1949,9 +1949,7 @@ def roc_auc_score(
 
         # Average it and compute AUC
         mean_tpr /= len(y_score)
-        fpr_macro = fpr_grid
-        tpr_macro = mean_tpr
-        roc_auc = _compute_area(tpr_macro.tolist()[::-1], fpr_macro.tolist()[::-1])
+        roc_auc = _compute_area(mean_tpr.tolist()[::-1], fpr_grid.tolist()[::-1])
         return roc_auc
     else:
         return _compute_multiclass_metric(
@@ -2075,10 +2073,8 @@ def prc_auc_score(
             recall_sorted, precision_sorted = zip(*sorted_pairs)
             mean_precision += np.interp(recall_grid, recall_sorted, precision_sorted)
         mean_precision /= len(y_score)
-        recall_macro = recall_grid
-        precision_macro = mean_precision
         prc_auc = _compute_area(
-            precision_macro.tolist()[::-1], recall_macro.tolist()[::-1]
+            mean_precision.tolist()[::-1], recall_grid.tolist()[::-1]
         )
         return prc_auc
     else:


### PR DESCRIPTION
New method added to compute roc_auc_score using either "micro" or "macro" averaging. 
The format is as follows:
roc_auc_score(*name of y_true columns*, *list of columns with score for all the classes*, *input relation/vDataFrame*, *average kind*, *list of labels*.

note that the list of labels and y_score columns should be in a matching order i.e. the first element in the labels list should match the first element in the score list.

For example: 

```python
import verticapy.machine_learning.metrics.classification as vpy_metrics
vpy_metrics.roc_auc_score("y_true_num", ["y_prob0","y_prob1","y_prob2"], vdf,average="macro",labels=['0','1','2'])
```
Next: Need to update unit tests by un-skipping the relevant tests.

closes #641 