### PR TITLE
Matplotlib Regression Plot - Color parameter fix

### DIFF
--- a/verticapy/plotting/_matplotlib/machine_learning/regression.py
+++ b/verticapy/plotting/_matplotlib/machine_learning/regression.py
@@ -61,6 +61,7 @@ class RegressionPlot(MatplotlibBase):
         """
         Draws a regression plot using the Matplotlib API.
         """
+        style_kwargs = self._fix_color_style_kwargs(style_kwargs)
         x0 = self.data["X"][:, 0]
         y0 = self.data["X"][:, 1]
         min_reg_x, max_reg_x = min(x0), max(x0)


### PR DESCRIPTION
Now "color" and "colors" are both accepted as valid aprameters