### PR TITLE
Some bug fixes for doc strings

### DIFF
--- a/verticapy/_config/config.py
+++ b/verticapy/_config/config.py
@@ -386,12 +386,14 @@ def set_option(key: str, value: Any = None) -> None:
 
     .. important:: The API will exclusively use these colors for drawing graphics.
 
-    .. ipython:: python
+    .. code-block:: python
 
         set_option("colors", ["blue", "red"])
 
-        @savefig _config_config_set_option_hist.png
-        titanic.hist(["pclass", "survived"])
+    .. warning:: 
+
+        This can be unstable if not enough colors are provided. It is advised to 
+        use the plotting library color options to switch colors.
 
     Utilities
     =========

--- a/verticapy/_config/config.py
+++ b/verticapy/_config/config.py
@@ -386,14 +386,23 @@ def set_option(key: str, value: Any = None) -> None:
 
     .. important:: The API will exclusively use these colors for drawing graphics.
 
-    .. code-block:: python
+    .. ipython:: python
 
         set_option("colors", ["blue", "red"])
+
+        @savefig _config_config_set_option_hist.png
+        titanic.hist(["pclass", "survived"])
 
     .. warning::
 
         This can be unstable if not enough colors are provided. It is advised to
         use the plotting library color options to switch colors.
+
+    .. ipython:: python
+        :suppress:
+
+        set_option("colors", None)
+
 
     Utilities
     =========

--- a/verticapy/_config/config.py
+++ b/verticapy/_config/config.py
@@ -390,9 +390,9 @@ def set_option(key: str, value: Any = None) -> None:
 
         set_option("colors", ["blue", "red"])
 
-    .. warning:: 
+    .. warning::
 
-        This can be unstable if not enough colors are provided. It is advised to 
+        This can be unstable if not enough colors are provided. It is advised to
         use the plotting library color options to switch colors.
 
     Utilities

--- a/verticapy/jupyter/extensions/chart_magic.py
+++ b/verticapy/jupyter/extensions/chart_magic.py
@@ -356,7 +356,7 @@ def chart_magic(
     .. ipython:: python
         :suppress:
 
-        %load_ext verticapy.chart
+        %load_ext verticapy.hchart
 
     Run the following to load some sample datasets. Once loaded, these datasets are
     stored in the 'public' schema. You can change the target schema with the

--- a/verticapy/sql/geo/index.py
+++ b/verticapy/sql/geo/index.py
@@ -274,6 +274,7 @@ def rename_index(source: str, dest: str, overwrite: bool = False) -> bool:
         :file: SPHINX_DIRECTORY/figures/sql_geo_index_rename_index_1.html
 
     .. ipython:: python
+        :okwarning:
 
         # Renames a specific index
         rename_index("world_polygons", "world_polygons_new")

--- a/verticapy/sql/insert.py
+++ b/verticapy/sql/insert.py
@@ -84,16 +84,16 @@ def insert_into(
         insert_into(
             table_name = "iris",
             schema = "public",
-            data = [[3.3, 4.5, 5.6, 7.8, "Iris-setosa"],
-                    [4.3, 4.7, 9.6, 1.8, "Iris-virginica"]],
+            data = [[1001, 3.3, 4.5, 5.6, 7.8, "Iris-setosa"],
+                    [1002, 4.3, 4.7, 9.6, 1.8, "Iris-virginica"]],
         )
 
         # copy set to False: multiple inserts
         insert_into(
             table_name = "iris",
             schema = "public",
-            data = [[3.3, 4.5, 5.6, 7.8, "Iris-setosa"],
-                    [4.3, 4.7, 9.6, 1.8, "Iris-virginica"]],
+            data = [[1001, 3.3, 4.5, 5.6, 7.8, "Iris-setosa"],
+                    [1002, 4.3, 4.7, 9.6, 1.8, "Iris-virginica"]],
             copy=False,
         )
 
@@ -102,8 +102,8 @@ def insert_into(
         insert_into(
             table_name = "iris",
             schema = "public",
-            data = [[3.3, 4.5, 5.6, 7.8, "Iris-setosa"],
-                    [4.3, 4.7, 9.6, 1.8, "Iris-virginica"]],
+            data = [[1001, 3.3, 4.5, 5.6, 7.8, "Iris-setosa"],
+                    [1002, 4.3, 4.7, 9.6, 1.8, "Iris-virginica"]],
             genSQL=True,
         )
 


### PR DESCRIPTION
- config file was changing color for the entire environment without reverting back
- chart magic was using verticapy.chart
- there was a warning that needed to be acknowledged

@oualib if there is a way to revert back colors then i can update this