### PR TITLE
Renaming "normalize" to the correct name

### DIFF
--- a/verticapy/core/vdataframe/_machine_learning.py
+++ b/verticapy/core/vdataframe/_machine_learning.py
@@ -32,7 +32,7 @@ from verticapy._utils._sql._random import _seeded_random_function
 
 from verticapy.core.tablesample.base import TableSample
 
-from verticapy.core.vdataframe._normalize import vDFNorm
+from verticapy.core.vdataframe._scaler import vDFScaler
 
 from verticapy.machine_learning.memmodel.tree import NonBinaryTree
 from verticapy.machine_learning.metrics import FUNCTIONS_DICTIONNARY
@@ -41,7 +41,7 @@ if TYPE_CHECKING:
     from verticapy.core.vdataframe.base import vDataFrame
 
 
-class vDFMachineLearning(vDFNorm):
+class vDFMachineLearning(vDFScaler):
     @save_verticapy_logs
     def add_duplicates(
         self, weight: Union[int, str], use_gcd: bool = True

--- a/verticapy/core/vdataframe/_plotting.py
+++ b/verticapy/core/vdataframe/_plotting.py
@@ -40,7 +40,7 @@ from verticapy._utils._sql._sys import _executeSQL
 from verticapy.core.tablesample.base import TableSample
 
 from verticapy.core.vdataframe._machine_learning import vDFMachineLearning
-from verticapy.core.vdataframe._normalize import vDCNorm
+from verticapy.core.vdataframe._scaler import vDCScaler
 
 from verticapy.plotting.base import PlottingBase
 
@@ -1274,7 +1274,7 @@ class vDFPlot(vDFMachineLearning):
         ).draw(**kwargs)
 
 
-class vDCPlot(vDCNorm):
+class vDCPlot(vDCScaler):
     # Special Methods.
 
     def numh(

--- a/verticapy/machine_learning/vertica/automl/clustering.py
+++ b/verticapy/machine_learning/vertica/automl/clustering.py
@@ -133,7 +133,7 @@ class AutoClustering(VerticaModel):
         preprocess_data: bool = True,
         preprocess_dict: dict = {
             "identify_ts": False,
-            "normalize_min_cat": 0,
+            "standardize_min_cat": 0,
             "outliers_threshold": 3.0,
             "na_method": "drop",
         },

--- a/verticapy/machine_learning/vertica/automl/dataprep.py
+++ b/verticapy/machine_learning/vertica/automl/dataprep.py
@@ -85,7 +85,7 @@ class AutoDataPrep(VerticaModel):
         merges the others  into one unique category. If
         unspecified, all categories are kept.
     standardize: bool, optional
-        If True, the data is standardized. The 'num_method' 
+        If True, the data is standardized. The 'num_method'
         parameter must be set to 'none'.
     standardize_min_cat: int, optional
         Minimum   feature   cardinality  before   using

--- a/verticapy/machine_learning/vertica/automl/dataprep.py
+++ b/verticapy/machine_learning/vertica/automl/dataprep.py
@@ -84,13 +84,12 @@ class AutoDataPrep(VerticaModel):
         Keeps  the top-k  most frequent categories  and
         merges the others  into one unique category. If
         unspecified, all categories are kept.
-    normalize: bool, optional
-        If True, the data is normalized using  the
-        z-score. The 'num_method' parameter must be set
-        to 'none'.
-    normalize_min_cat: int, optional
+    standardize: bool, optional
+        If True, the data is standardized. The 'num_method' 
+        parameter must be set to 'none'.
+    standardize_min_cat: int, optional
         Minimum   feature   cardinality  before   using
-        normalization.
+        standardization.
     id_method: str, optional
         Method for handling ID features.
             drop: Drops any feature detected as ID.
@@ -168,8 +167,8 @@ class AutoDataPrep(VerticaModel):
         outliers_threshold: float = 4.0,
         na_method: Literal["auto", "drop"] = "auto",
         cat_topk: int = 10,
-        normalize: bool = True,
-        normalize_min_cat: int = 6,
+        standardize: bool = True,
+        standardize_min_cat: int = 6,
         id_method: Literal["none", "drop"] = "drop",
         apply_pca: bool = False,
         rule: TimeInterval = "auto",
@@ -186,8 +185,8 @@ class AutoDataPrep(VerticaModel):
             "na_method": na_method,
             "cat_topk": cat_topk,
             "rule": rule,
-            "normalize": normalize,
-            "normalize_min_cat": normalize_min_cat,
+            "standardize": standardize,
+            "standardize_min_cat": standardize_min_cat,
             "apply_pca": apply_pca,
             "id_method": id_method,
             "identify_ts": identify_ts,
@@ -288,16 +287,16 @@ class AutoDataPrep(VerticaModel):
                             )
                         if (
                             self.parameters["num_method"] == "none"
-                            and (self.parameters["normalize"])
+                            and (self.parameters["standardize"])
                             and (
-                                self.parameters["normalize_min_cat"] < 2
+                                self.parameters["standardize_min_cat"] < 2
                                 or (
                                     vdf[x].nunique()
-                                    > self.parameters["normalize_min_cat"]
+                                    > self.parameters["standardize_min_cat"]
                                 )
                             )
                         ):
-                            vdf[x].normalize(method="zscore")
+                            vdf[x].scale(method="zscore")
                         if self.parameters["na_method"] == "auto":
                             vdf[x].fillna(method="mean")
                         else:

--- a/verticapy/machine_learning/vertica/preprocessing.py
+++ b/verticapy/machine_learning/vertica/preprocessing.py
@@ -656,10 +656,10 @@ class Scaler(Preprocessing):
         name as an existing model overwrites the
         existing model.
     method: str, optional
-        Method used to normalize.
-                zscore        : Normalization   using   the   Z-Score.
+        Method used to scale the data.
+                zscore        : Scaling   using   the   Z-Score.
                             (x - avg) / std
-                robust_zscore : Normalization using the Robust Z-Score.
+                robust_zscore : Scaling using the Robust Z-Score.
                                 (x - median) / (1.4826 * mad)
                 minmax        : Normalization  using  the  Min  &  Max.
                                 (x - min) / (max - min)

--- a/verticapy/tests/udf/pmath.py
+++ b/verticapy/tests/udf/pmath.py
@@ -1,2 +1,2 @@
-def normalize_titanic(age, fare):
+def scale_titanic(age, fare):
     return (age - 30.15) / 14.44, (fare - 33.96) / 52.65

--- a/verticapy/tests/udf/test_udf.py
+++ b/verticapy/tests/udf/test_udf.py
@@ -26,7 +26,7 @@ import verticapy
 from verticapy.udf import generate_lib_udf
 
 
-def normalize_titanic(age, fare):
+def scale_titanic(age, fare):
     return (age - 30.15) / 14.44, (fare - 33.96) / 52.65
 
 
@@ -45,7 +45,7 @@ class TestUdf:
                     "python_isclose",
                 ),
                 (
-                    normalize_titanic,
+                    scale_titanic,
                     [float, float],
                     {"norm_age": float, "norm_fare": float},
                     {},

--- a/verticapy/tests/vDataFrame/test_vDF_feature_engineering.py
+++ b/verticapy/tests/vDataFrame/test_vDF_feature_engineering.py
@@ -602,7 +602,7 @@ class TestvDFFeatureEngineering:
         # Testing vDataFrame.abs
         titanic_copy = titanic_vd.copy()
 
-        titanic_copy.normalize(["fare", "age"])
+        titanic_copy.scale(["fare", "age"])
         assert titanic_copy["fare"].min() == pytest.approx(-0.64513441)
         assert titanic_copy["age"].min() == pytest.approx(-2.0659389)
 
@@ -612,7 +612,7 @@ class TestvDFFeatureEngineering:
 
         # Testing vDataFrame[].abs
         titanic_copy = titanic_vd.copy()
-        titanic_copy["fare"].normalize()
+        titanic_copy["fare"].scale()
         titanic_copy["fare"].abs()
 
         assert titanic_copy["fare"].min() == pytest.approx(0.001082821)

--- a/verticapy/tests/vDataFrame/test_vDF_preprocessing.py
+++ b/verticapy/tests/vDataFrame/test_vDF_preprocessing.py
@@ -386,46 +386,46 @@ class TestvDFPreprocessing:
         market_copy["Price"].fill_outliers(method="mean", threshold=1.5)
         assert market_copy["Price"].mean() == pytest.approx(2.07751098603612)
 
-    def test_vDF_normalize(self, titanic_vd):
-        ### Testing vDataFrame.normalize
+    def test_vDF_scale(self, titanic_vd):
+        ### Testing vDataFrame.scale
         # MINMAX
         titanic_copy = titanic_vd.copy()
-        titanic_copy.normalize(method="minmax")
+        titanic_copy.scale(method="minmax")
 
         assert titanic_copy["fare"].mean() == pytest.approx(0.06629291024)
         assert titanic_copy["age"].mean() == pytest.approx(0.3743248069)
 
         # ZSCORE
         titanic_copy = titanic_vd.copy()
-        titanic_copy.normalize(columns=["fare", "age"], method="zscore")
+        titanic_copy.scale(columns=["fare", "age"], method="zscore")
 
         assert titanic_copy["fare"].std() == 1
         assert titanic_copy["age"].std() == 1
 
         # ROBUST_ZSCORE
         titanic_copy = titanic_vd.copy()
-        titanic_copy.normalize(["fare", "age"], method="robust_zscore")
+        titanic_copy.scale(["fare", "age"], method="robust_zscore")
 
         assert titanic_copy["fare"].std() == pytest.approx(5.143143267)
         assert titanic_copy["age"].std() == pytest.approx(1.21705994)
 
-        ### Testing vDataFrame.normalize
+        ### Testing vDataFrame.scale
         titanic_copy = titanic_vd.copy()
 
         # MINMAX
-        titanic_copy["fare"].normalize(method="minmax")
+        titanic_copy["fare"].scale(method="minmax")
         assert titanic_copy["fare"].mean() == pytest.approx(0.06629291024)
 
         # ZSCORE
-        titanic_copy["age"].normalize(method="zscore")
+        titanic_copy["age"].scale(method="zscore")
         assert titanic_copy["age"].std() == 1
 
         # ROBUST_ZSCORE
-        titanic_copy["body"].normalize(method="robust_zscore")
+        titanic_copy["body"].scale(method="robust_zscore")
         assert titanic_copy["body"].std() == pytest.approx(0.727817135)
 
         # using by parameter
-        titanic_copy["sibsp"].normalize(method="minmax", by=["sex"])
+        titanic_copy["sibsp"].scale(method="minmax", by=["sex"])
         assert titanic_copy["sibsp"].mean() == pytest.approx(0.06300648298)
 
     def test_vDF_outliers(self, titanic_vd):

--- a/verticapy/tests_new/core/vdataframe/test_normalize.py
+++ b/verticapy/tests_new/core/vdataframe/test_normalize.py
@@ -18,30 +18,30 @@ from scipy.stats import median_abs_deviation
 import pytest
 
 
-class TestNormalize:
+class TestScaler:
     """
-    test class for Normalize function test
+    test class for Scale function test
     """
 
     @pytest.mark.parametrize(
         "columns, method",
         [("age", "zscore"), ("age", "robust_zscore"), ("age", "minmax")],
     )
-    def test_normalize_vdf(self, titanic_vd, columns, method):
+    def test_scale_vdf(self, titanic_vd, columns, method):
         """
-        test function - normalize for vDataframe
+        test function - scaling for vDataframe
         """
         titanic_pdf = titanic_vd.to_pandas()
         titanic_pdf[columns] = titanic_pdf[columns].astype(float)
 
         py_data = titanic_pdf[[columns]]
         if method == "zscore":
-            vpy_res = titanic_vd.normalize(columns=[columns], method=method)[
+            vpy_res = titanic_vd.scale(columns=[columns], method=method)[
                 columns
             ].std()
             py_res = ((py_data - py_data.mean()) / py_data.std()).std()
         elif method == "robust_zscore":
-            vpy_res = titanic_vd.normalize(columns=[columns], method=method)[
+            vpy_res = titanic_vd.scale(columns=[columns], method=method)[
                 columns
             ].std()
             py_res = (
@@ -49,7 +49,7 @@ class TestNormalize:
                 / (1.4826 * median_abs_deviation(py_data, nan_policy="omit"))
             ).std()
         else:
-            vpy_res = titanic_vd.normalize(columns=[columns], method=method)[
+            vpy_res = titanic_vd.scale(columns=[columns], method=method)[
                 columns
             ].mean()
             py_res = (
@@ -67,9 +67,9 @@ class TestNormalize:
         [("age", "zscore"), ("age", "robust_zscore"), ("age", "minmax")],
     )
     @pytest.mark.parametrize("partition_by", ["pclass", None])
-    def test_normalize_vcolumn(self, titanic_vd_fun, partition_by, columns, method):
+    def test_scale_vcolumn(self, titanic_vd_fun, partition_by, columns, method):
         """
-        test function - normalize for vColumns
+        test function - scaling for vColumns
         """
         titanic_pdf = titanic_vd_fun.to_pandas()
         titanic_pdf[columns] = titanic_pdf[columns].astype(float)
@@ -77,17 +77,17 @@ class TestNormalize:
         vpy_data = titanic_vd_fun[columns]
 
         if method == "zscore":
-            vpy_res = vpy_data.normalize(method=method, by=partition_by)[columns].std()
+            vpy_res = vpy_data.scale(method=method, by=partition_by)[columns].std()
             py_res = ((py_data - py_data.mean()) / py_data.std()).std()
         elif method == "robust_zscore":
-            vpy_res = vpy_data.normalize(method=method)[columns].std()
+            vpy_res = vpy_data.scale(method=method)[columns].std()
             # vpy_res = _res.std() if partition_by else _res["age"].std()
             py_res = (
                 (py_data - py_data.median())
                 / (1.4826 * median_abs_deviation(py_data, nan_policy="omit"))
             ).std()
         else:
-            vpy_res = vpy_data.normalize(method=method, by=partition_by)[columns].mean()
+            vpy_res = vpy_data.scale(method=method, by=partition_by)[columns].mean()
             py_res = (
                 (py_data - py_data.min()) / (py_data.max() - py_data.min())
             ).mean()

--- a/verticapy/tests_new/core/vdataframe/test_normalize.py
+++ b/verticapy/tests_new/core/vdataframe/test_normalize.py
@@ -36,22 +36,16 @@ class TestScaler:
 
         py_data = titanic_pdf[[columns]]
         if method == "zscore":
-            vpy_res = titanic_vd.scale(columns=[columns], method=method)[
-                columns
-            ].std()
+            vpy_res = titanic_vd.scale(columns=[columns], method=method)[columns].std()
             py_res = ((py_data - py_data.mean()) / py_data.std()).std()
         elif method == "robust_zscore":
-            vpy_res = titanic_vd.scale(columns=[columns], method=method)[
-                columns
-            ].std()
+            vpy_res = titanic_vd.scale(columns=[columns], method=method)[columns].std()
             py_res = (
                 (py_data - py_data.median())
                 / (1.4826 * median_abs_deviation(py_data, nan_policy="omit"))
             ).std()
         else:
-            vpy_res = titanic_vd.scale(columns=[columns], method=method)[
-                columns
-            ].mean()
+            vpy_res = titanic_vd.scale(columns=[columns], method=method)[columns].mean()
             py_res = (
                 (py_data - py_data.min()) / (py_data.max() - py_data.min())
             ).mean()


### PR DESCRIPTION
 - important as it confuses user.
 - .normalize method is still available but is not an alias of scale