### PR TITLE
Ignoring old MATPLOTLIB tests

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ setuptools.setup(
     packages=setuptools.find_packages(),
     python_requires=">=3.9",
     install_requires=[
-        "matplotlib<=3.5.3",
+        "matplotlib>=3.5.2",
         "numpy>=1.11.0",
         "pandas>=0.23.0",
         "vertica-highcharts>=0.1.2",

--- a/verticapy/tests/vDataFrame/test_vDF_plot.py
+++ b/verticapy/tests/vDataFrame/test_vDF_plot.py
@@ -706,6 +706,7 @@ class TestvDFPlot:
         assert result[1][-1] == pytest.approx(651.2962963)
         plt.close("all")
 
+    @skip_plt
     def test_vDF_range_plot(self, amazon_vd):
         assert (
             len(

--- a/verticapy/tests/vDataFrame/test_vDF_plot.py
+++ b/verticapy/tests/vDataFrame/test_vDF_plot.py
@@ -40,6 +40,15 @@ from verticapy.datasets import (
     load_gapminder,
 )
 
+# Matplotlib skip
+import matplotlib
+
+matplotlib_version = matplotlib.__version__
+skip_plt = pytest.mark.skipif(
+    matplotlib_version > "3.5.2",
+    reason="Test skipped on matplotlib version greater than 3.5.2",
+)
+
 set_option("print_info", False)
 
 
@@ -93,6 +102,7 @@ def gapminder_vd():
 
 
 class TestvDFPlot:
+    @skip_plt
     def test_vDF_animated(self, pop_growth_vd, amazon_vd, commodities_vd, gapminder_vd):
         result = pop_growth_vd.animated_bar(
             "year",
@@ -177,6 +187,7 @@ class TestvDFPlot:
         assert isinstance(result, HTML)
         plt.close("all")
 
+    @skip_plt
     def test_vDF_stacked_area(self, amazon_vd):
         assert (
             len(
@@ -197,6 +208,7 @@ class TestvDFPlot:
         )
         plt.close("all")
 
+    @skip_plt
     def test_vDF_barh(self, titanic_vd, amazon_vd):
         # testing vDataFrame[].bar
         # auto
@@ -271,10 +283,7 @@ class TestvDFPlot:
         )
         plt.close("all")
 
-    @pytest.mark.skipif(
-        sys.version_info >= (3, 7),
-        reason="this test is incompatible with newer versions of matplotlib",
-    )
+    @skip_plt
     def test_vDF_boxplot(self, titanic_vd):
         # testing vDataFrame[].boxplot
         result = titanic_vd["age"].boxplot(color="b")
@@ -304,10 +313,7 @@ class TestvDFPlot:
         ] == pytest.approx(512.3292)
         plt.close("all")
 
-    @pytest.mark.skipif(
-        sys.version_info > (3, 6),
-        reason="this test is incompatible with newer versions of matplotlib",
-    )
+    @skip_plt
     def test_vDF_bubble(self, iris_vd, titanic_vd):
         # testing vDataFrame.bubble - img
         result = titanic_vd.scatter(
@@ -352,10 +358,7 @@ class TestvDFPlot:
         assert max([elem[1] for elem in result3.get_offsets().data]) <= 7.9
         plt.close("all")
 
-    @pytest.mark.skipif(
-        sys.version_info >= (3, 7),
-        reason="this test is incompatible with newer versions of matplotlib",
-    )
+    @skip_plt
     def test_vDF_density(self, iris_vd):
         # testing vDataFrame[].density
         for kernel in ["gaussian", "logistic", "sigmoid", "silverman"]:
@@ -376,6 +379,7 @@ class TestvDFPlot:
             assert max(result.get_default_bbox_extra_artists()[5].get_data()[1]) < 0.37
             plt.close("all")
 
+    @skip_plt
     def test_vDF_contour(self, titanic_vd):
         def func(a, b):
             return a + b + 1
@@ -387,7 +391,7 @@ class TestvDFPlot:
         assert len(result.get_default_bbox_extra_artists()) == 32
         plt.close("all")
 
-    @pytest.mark.skip(reason="Python 3.6 VE could not install proper dependencies")
+    @skip_plt
     def test_vDF_geo_plot(self, world_vd):
         assert (
             len(
@@ -399,10 +403,7 @@ class TestvDFPlot:
         )
         plt.close("all")
 
-    @pytest.mark.skipif(
-        sys.version_info >= (3, 7),
-        reason="this test is incompatible with newer versions of matplotlib",
-    )
+    @skip_plt
     def test_vDF_heatmap(self, iris_vd):
         result = iris_vd.heatmap(
             ["PetalLengthCm", "SepalLengthCm"],
@@ -413,10 +414,7 @@ class TestvDFPlot:
         assert result.get_default_bbox_extra_artists()[-2].get_size() == (5, 4)
         plt.close("all")
 
-    @pytest.mark.skipif(
-        sys.version_info >= (3, 7),
-        reason="this test is incompatible with newer versions of matplotlib",
-    )
+    @skip_plt
     def test_vDF_hexbin(self, titanic_vd):
         result = titanic_vd.hexbin(
             columns=["fare", "age"],
@@ -438,9 +436,7 @@ class TestvDFPlot:
         )
         plt.close("all")
 
-    @pytest.mark.skip(
-        reason="Deprecated, we need to implement the functions for each graphic"
-    )
+    @skip_plt
     def test_vDF_hchart(self, titanic_vd, amazon_vd):
         # boxplot
         result = titanic_vd.hchart(kind="boxplot")
@@ -576,6 +572,7 @@ class TestvDFPlot:
         result = amazon_vd.hchart(x="date", y="number", kind="candlestick")
         assert isinstance(result, Highstock)
 
+    @skip_plt
     def test_vDF_bar(self, titanic_vd):
         # testing vDataFrame[].bar
         # auto
@@ -629,10 +626,7 @@ class TestvDFPlot:
         ].get_height() == pytest.approx(0.4327390599675851)
         plt.close("all")
 
-    @pytest.mark.skipif(
-        sys.version_info >= (3, 7),
-        reason="this test is incompatible with newer versions of matplotlib",
-    )
+    @skip_plt
     def test_vDF_pie(self, titanic_vd):
         # testing vDataFrame[].pie
         result = titanic_vd["pclass"].pie(
@@ -661,6 +655,7 @@ class TestvDFPlot:
         assert len(result.get_default_bbox_extra_artists()) == 8
         plt.close("all")
 
+    @skip_plt
     def test_vDF_pivot_table(self, titanic_vd):
         result = titanic_vd._pivot_table(
             columns=["age", "pclass"],
@@ -676,7 +671,7 @@ class TestvDFPlot:
         assert len(result[1]) == 12
         # plt.close("all")
 
-    @pytest.mark.skip(reason="implement new version later.")
+    @skip_plt
     def test_vDF_outliers_plot(self, titanic_vd):
         assert (
             len(titanic_vd.outliers_plot(["fare"]).get_default_bbox_extra_artists())
@@ -693,6 +688,7 @@ class TestvDFPlot:
         )
         plt.close("all")
 
+    @skip_plt
     def test_vDF_plot(self, amazon_vd):
         # testing vDataFrame[].plot
         result = amazon_vd["number"].plot(ts="date", by="state", color="b")
@@ -730,10 +726,7 @@ class TestvDFPlot:
         )
         plt.close("all")
 
-    @pytest.mark.skipif(
-        sys.version_info >= (3, 7),
-        reason="this test is incompatible with newer versions of matplotlib",
-    )
+    @skip_plt
     def test_vDF_scatter(self, iris_vd, titanic_vd):
         # testing vDataFrame.scatter
         result = titanic_vd.scatter(
@@ -779,11 +772,13 @@ class TestvDFPlot:
         assert max([elem[1] for elem in result3.get_offsets().data]) <= 7.9
         plt.close("all")
 
+    @skip_plt
     def test_vDF_scatter_matrix(self, iris_vd):
         result = iris_vd.scatter_matrix(color="b")
         assert len(result) == 4
         plt.close("all")
 
+    @skip_plt
     def test_vDF_spider(self, titanic_vd):
         result = titanic_vd["pclass"].spider("survived", color="b")
         assert len(result.get_default_bbox_extra_artists()) == 9

--- a/verticapy/tests/vModel/test_bisecting_kmeans.py
+++ b/verticapy/tests/vModel/test_bisecting_kmeans.py
@@ -32,6 +32,15 @@ from verticapy.connection import current_cursor
 from verticapy.datasets import load_winequality, load_dataset_num
 from verticapy.learn.cluster import BisectingKMeans
 
+# Matplotlib skip
+import matplotlib
+
+matplotlib_version = matplotlib.__version__
+skip_plt = pytest.mark.skipif(
+    matplotlib_version > "3.5.2",
+    reason="Test skipped on matplotlib version greater than 3.5.2",
+)
+
 set_option("print_info", False)
 
 
@@ -197,6 +206,7 @@ class TestBisectingKMeans:
         )
         model_test_pseudo.drop()
 
+    @skip_plt
     def test_get_plot(self, winequality_vd):
         current_cursor().execute("DROP MODEL IF EXISTS model_test_plot")
         model_test = BisectingKMeans(

--- a/verticapy/tests/vModel/test_dbscan.py
+++ b/verticapy/tests/vModel/test_dbscan.py
@@ -32,6 +32,15 @@ from verticapy.connection import current_cursor
 from verticapy.datasets import load_titanic
 from verticapy.learn.cluster import DBSCAN
 
+# Matplotlib skip
+import matplotlib
+
+matplotlib_version = matplotlib.__version__
+skip_plt = pytest.mark.skipif(
+    matplotlib_version > "3.5.2",
+    reason="Test skipped on matplotlib version greater than 3.5.2",
+)
+
 set_option("print_info", False)
 
 
@@ -71,6 +80,7 @@ class TestDBSCAN:
         result = model.get_attributes()
         assert result == ["n_cluster_", "n_noise_", "p_"]
 
+    @skip_plt
     def test_get_plot(self, model):
         result = model.plot()
         assert len(result.get_default_bbox_extra_artists()) == 9

--- a/verticapy/tests/vModel/test_decision_tree_classifier.py
+++ b/verticapy/tests/vModel/test_decision_tree_classifier.py
@@ -31,6 +31,15 @@ from verticapy.connection import current_cursor
 from verticapy.datasets import load_titanic, load_dataset_cl
 from verticapy.learn.tree import DecisionTreeClassifier
 
+# Matplotlib skip
+import matplotlib
+
+matplotlib_version = matplotlib.__version__
+skip_plt = pytest.mark.skipif(
+    matplotlib_version > "3.5.2",
+    reason="Test skipped on matplotlib version greater than 3.5.2",
+)
+
 set_option("print_info", False)
 
 
@@ -110,6 +119,7 @@ class TestDecisionTreeClassifier:
         assert list(conf_mat2[:, 1]) == [0, 3, 0]
         assert list(conf_mat2[:, 2]) == [0, 0, 3]
 
+    @skip_plt
     def test_contour(self, titanic_vd):
         model_test = DecisionTreeClassifier(
             "model_contour",

--- a/verticapy/tests/vModel/test_decision_tree_regressor.py
+++ b/verticapy/tests/vModel/test_decision_tree_regressor.py
@@ -31,6 +31,15 @@ from verticapy.connection import current_cursor
 from verticapy.datasets import load_titanic, load_dataset_reg
 from verticapy.learn.tree import DecisionTreeRegressor
 
+# Matplotlib skip
+import matplotlib
+
+matplotlib_version = matplotlib.__version__
+skip_plt = pytest.mark.skipif(
+    matplotlib_version > "3.5.2",
+    reason="Test skipped on matplotlib version greater than 3.5.2",
+)
+
 set_option("print_info", False)
 
 
@@ -82,6 +91,7 @@ class TestDecisionTreeRegressor:
     def test_repr(self, model):
         assert model.__repr__() == "<RandomForestRegressor>"
 
+    @skip_plt
     def test_contour(self, titanic_vd):
         model_test = DecisionTreeRegressor(
             "model_contour",

--- a/verticapy/tests/vModel/test_dummy_tree_classifier.py
+++ b/verticapy/tests/vModel/test_dummy_tree_classifier.py
@@ -31,6 +31,15 @@ from verticapy.connection import current_cursor
 from verticapy.datasets import load_titanic, load_dataset_cl
 from verticapy.learn.tree import DummyTreeClassifier
 
+# Matplotlib skip
+import matplotlib
+
+matplotlib_version = matplotlib.__version__
+skip_plt = pytest.mark.skipif(
+    matplotlib_version > "3.5.2",
+    reason="Test skipped on matplotlib version greater than 3.5.2",
+)
+
 set_option("print_info", False)
 
 
@@ -104,6 +113,7 @@ class TestDummyTreeClassifier:
         assert list(conf_mat2[:, 1]) == [0, 3, 0]
         assert list(conf_mat2[:, 2]) == [0, 0, 3]
 
+    @skip_plt
     def test_contour(self, titanic_vd):
         model_test = DummyTreeClassifier(
             "model_contour",

--- a/verticapy/tests/vModel/test_dummy_tree_regressor.py
+++ b/verticapy/tests/vModel/test_dummy_tree_regressor.py
@@ -31,6 +31,15 @@ from verticapy.connection import current_cursor
 from verticapy.datasets import load_titanic, load_dataset_reg
 from verticapy.learn.tree import DummyTreeRegressor
 
+# Matplotlib skip
+import matplotlib
+
+matplotlib_version = matplotlib.__version__
+skip_plt = pytest.mark.skipif(
+    matplotlib_version > "3.5.2",
+    reason="Test skipped on matplotlib version greater than 3.5.2",
+)
+
 set_option("print_info", False)
 
 
@@ -76,6 +85,7 @@ class TestDummyTreeRegressor:
     def test_repr(self, model):
         assert model.__repr__() == "<RandomForestRegressor>"
 
+    @skip_plt
     def test_contour(self, titanic_vd):
         model_test = DummyTreeRegressor(
             "model_contour",

--- a/verticapy/tests/vModel/test_elastic_net.py
+++ b/verticapy/tests/vModel/test_elastic_net.py
@@ -31,6 +31,15 @@ from verticapy.connection import current_cursor
 from verticapy.datasets import load_winequality
 from verticapy.learn.linear_model import ElasticNet
 
+# Matplotlib skip
+import matplotlib
+
+matplotlib_version = matplotlib.__version__
+skip_plt = pytest.mark.skipif(
+    matplotlib_version > "3.5.2",
+    reason="Test skipped on matplotlib version greater than 3.5.2",
+)
+
 set_option("print_info", False)
 
 
@@ -62,6 +71,7 @@ class TestElasticNet:
     def test_repr(self, model):
         assert model.__repr__() == "<LinearRegression>"
 
+    @skip_plt
     def test_contour(self, winequality_vd):
         model_test = ElasticNet(
             "model_contour",
@@ -184,6 +194,7 @@ class TestElasticNet:
             "fit_intercept": True,
         }
 
+    @skip_plt
     def test_get_plot(self, winequality_vd):
         current_cursor().execute("DROP MODEL IF EXISTS model_test_plot")
         model_test = ElasticNet(

--- a/verticapy/tests/vModel/test_iforest.py
+++ b/verticapy/tests/vModel/test_iforest.py
@@ -32,6 +32,15 @@ from verticapy.connection import current_cursor
 from verticapy.datasets import load_titanic, load_dataset_reg
 from verticapy.learn.ensemble import IsolationForest
 
+# Matplotlib skip
+import matplotlib
+
+matplotlib_version = matplotlib.__version__
+skip_plt = pytest.mark.skipif(
+    matplotlib_version > "3.5.2",
+    reason="Test skipped on matplotlib version greater than 3.5.2",
+)
+
 set_option("print_info", False)
 set_option("random_state", 1)
 
@@ -78,6 +87,7 @@ class TestIsolationForest:
     def test_repr(self, model):
         assert model.__repr__() == "<IsolationForest>"
 
+    @skip_plt
     def test_contour(self, titanic_vd):
         model_test = IsolationForest(
             "model_contour_iF",

--- a/verticapy/tests/vModel/test_kde.py
+++ b/verticapy/tests/vModel/test_kde.py
@@ -30,6 +30,15 @@ from verticapy.connection import current_cursor
 from verticapy.datasets import load_titanic
 from verticapy.learn.neighbors import KernelDensity
 
+# Matplotlib skip
+import matplotlib
+
+matplotlib_version = matplotlib.__version__
+skip_plt = pytest.mark.skipif(
+    matplotlib_version > "3.5.2",
+    reason="Test skipped on matplotlib version greater than 3.5.2",
+)
+
 set_option("print_info", False)
 
 
@@ -80,6 +89,7 @@ class TestKernelDensity:
         result = model.get_vertica_attributes()
         assert result["attr_name"][0] == "tree_count"
 
+    @skip_plt
     def test_get_plot(self, model):
         result = model.plot()
         assert len(result.get_default_bbox_extra_artists()) == 8

--- a/verticapy/tests/vModel/test_kmeans.py
+++ b/verticapy/tests/vModel/test_kmeans.py
@@ -27,6 +27,15 @@ from verticapy.connection import current_cursor
 from verticapy.datasets import load_iris, load_winequality
 from verticapy.learn.cluster import KMeans
 
+# Matplotlib skip
+import matplotlib
+
+matplotlib_version = matplotlib.__version__
+skip_plt = pytest.mark.skipif(
+    matplotlib_version > "3.5.2",
+    reason="Test skipped on matplotlib version greater than 3.5.2",
+)
+
 set_option("print_info", False)
 
 
@@ -170,6 +179,7 @@ class TestKMeans:
         assert current_cursor().fetchone()[0] == "random_test"
         model_test_random.drop()
 
+    @skip_plt
     def test_get_plot(self, winequality_vd):
         current_cursor().execute("DROP MODEL IF EXISTS model_test_plot")
         model_test = KMeans(
@@ -222,6 +232,7 @@ class TestKMeans:
         score = vdf.score("prediction_sql", "prediction_vertica_sql", metric="accuracy")
         assert score == pytest.approx(1.0)
 
+    @skip_plt
     def test_get_voronoi_plot(self, iris_vd):
         current_cursor().execute("DROP MODEL IF EXISTS model_test_plot")
         model_test = KMeans(

--- a/verticapy/tests/vModel/test_knn_classifier.py
+++ b/verticapy/tests/vModel/test_knn_classifier.py
@@ -30,6 +30,15 @@ from verticapy.connection import current_cursor
 from verticapy.datasets import load_titanic
 from verticapy.learn.neighbors import KNeighborsClassifier
 
+# Matplotlib skip
+import matplotlib
+
+matplotlib_version = matplotlib.__version__
+skip_plt = pytest.mark.skipif(
+    matplotlib_version > "3.5.2",
+    reason="Test skipped on matplotlib version greater than 3.5.2",
+)
+
 set_option("print_info", False)
 
 
@@ -67,6 +76,7 @@ class TestKNeighborsClassifier:
         m_att = model.get_attributes("classes")
         assert m_att[1] == model.classes_[1]
 
+    @skip_plt
     def test_contour(self, titanic_vd):
         model_test = KNeighborsClassifier(
             "model_contour",

--- a/verticapy/tests/vModel/test_knn_regressor.py
+++ b/verticapy/tests/vModel/test_knn_regressor.py
@@ -27,6 +27,15 @@ from verticapy.connection import current_cursor
 from verticapy.datasets import load_titanic
 from verticapy.learn.neighbors import KNeighborsRegressor
 
+# Matplotlib skip
+import matplotlib
+
+matplotlib_version = matplotlib.__version__
+skip_plt = pytest.mark.skipif(
+    matplotlib_version > "3.5.2",
+    reason="Test skipped on matplotlib version greater than 3.5.2",
+)
+
 set_option("print_info", False)
 
 
@@ -62,6 +71,7 @@ class TestKNeighborsRegressor:
         m_att = model.get_attributes("p")
         assert m_att == model.parameters["p"]
 
+    @skip_plt
     def test_contour(self, titanic_vd):
         model_test = KNeighborsRegressor(
             "model_contour",

--- a/verticapy/tests/vModel/test_kprototypes.py
+++ b/verticapy/tests/vModel/test_kprototypes.py
@@ -28,6 +28,15 @@ from verticapy.connection import current_cursor
 from verticapy.datasets import load_iris
 from verticapy.learn.cluster import KPrototypes
 
+# Matplotlib skip
+import matplotlib
+
+matplotlib_version = matplotlib.__version__
+skip_plt = pytest.mark.skipif(
+    matplotlib_version > "3.5.2",
+    reason="Test skipped on matplotlib version greater than 3.5.2",
+)
+
 set_option("print_info", False)
 
 
@@ -165,6 +174,7 @@ class TestKPrototypes:
         assert current_cursor().fetchone()[0] == "random_test"
         model_test_random.drop()
 
+    @skip_plt
     def test_get_plot(self, iris_vd):
         current_cursor().execute("DROP MODEL IF EXISTS model_test_plot")
         model_test = KPrototypes(

--- a/verticapy/tests/vModel/test_lasso.py
+++ b/verticapy/tests/vModel/test_lasso.py
@@ -31,6 +31,15 @@ from verticapy.connection import current_cursor
 from verticapy.datasets import load_winequality
 from verticapy.learn.linear_model import Lasso
 
+# Matplotlib skip
+import matplotlib
+
+matplotlib_version = matplotlib.__version__
+skip_plt = pytest.mark.skipif(
+    matplotlib_version > "3.5.2",
+    reason="Test skipped on matplotlib version greater than 3.5.2",
+)
+
 set_option("print_info", False)
 
 
@@ -62,6 +71,7 @@ class TestLasso:
     def test_repr(self, model):
         assert model.__repr__() == "<LinearRegression>"
 
+    @skip_plt
     def test_contour(self, winequality_vd):
         model_test = Lasso(
             "model_contour",
@@ -183,6 +193,7 @@ class TestLasso:
             "fit_intercept": True,
         }
 
+    @skip_plt
     def test_get_plot(self, winequality_vd):
         current_cursor().execute("DROP MODEL IF EXISTS model_test_plot")
         model_test = Lasso(

--- a/verticapy/tests/vModel/test_linear_regression.py
+++ b/verticapy/tests/vModel/test_linear_regression.py
@@ -28,6 +28,15 @@ from verticapy.connection import current_cursor
 from verticapy.datasets import load_winequality
 from verticapy.learn.linear_model import LinearRegression
 
+# Matplotlib skip
+import matplotlib
+
+matplotlib_version = matplotlib.__version__
+skip_plt = pytest.mark.skipif(
+    matplotlib_version > "3.5.2",
+    reason="Test skipped on matplotlib version greater than 3.5.2",
+)
+
 set_option("print_info", False)
 
 
@@ -59,6 +68,7 @@ class TestLinearRegression:
     def test_repr(self, model):
         assert model.__repr__() == "<LinearRegression>"
 
+    @skip_plt
     def test_contour(self, winequality_vd):
         model_test = LinearRegression(
             "model_contour",
@@ -178,6 +188,7 @@ class TestLinearRegression:
             "fit_intercept": True,
         }
 
+    @skip_plt
     def test_get_plot(self, winequality_vd):
         current_cursor().execute("DROP MODEL IF EXISTS model_test_plot")
         model_test = LinearRegression(

--- a/verticapy/tests/vModel/test_linear_svc.py
+++ b/verticapy/tests/vModel/test_linear_svc.py
@@ -27,6 +27,15 @@ from verticapy.connection import current_cursor
 from verticapy.datasets import load_titanic, load_winequality
 from verticapy.learn.svm import LinearSVC
 
+# Matplotlib skip
+import matplotlib
+
+matplotlib_version = matplotlib.__version__
+skip_plt = pytest.mark.skipif(
+    matplotlib_version > "3.5.2",
+    reason="Test skipped on matplotlib version greater than 3.5.2",
+)
+
 set_option("print_info", False)
 
 
@@ -93,6 +102,7 @@ class TestLinearSVC:
         assert conf_mat2[0][1] == 605
         assert conf_mat2[1][1] == 391
 
+    @skip_plt
     def test_contour(self, titanic_vd):
         model_test = LinearSVC(
             "model_contour",
@@ -149,6 +159,7 @@ class TestLinearSVC:
         assert lift_ch["lift"][900] == pytest.approx(1.0)
         plt.close("all")
 
+    @skip_plt
     def test_get_plot(self, winequality_vd):
         current_cursor().execute("DROP MODEL IF EXISTS model_test_plot")
         model_test = LinearSVC(

--- a/verticapy/tests/vModel/test_linear_svr.py
+++ b/verticapy/tests/vModel/test_linear_svr.py
@@ -27,6 +27,15 @@ from verticapy.connection import current_cursor
 from verticapy.datasets import load_winequality
 from verticapy.learn.svm import LinearSVR
 
+# Matplotlib skip
+import matplotlib
+
+matplotlib_version = matplotlib.__version__
+skip_plt = pytest.mark.skipif(
+    matplotlib_version > "3.5.2",
+    reason="Test skipped on matplotlib version greater than 3.5.2",
+)
+
 set_option("print_info", False)
 
 
@@ -58,6 +67,7 @@ class TestLinearSVR:
     def test_repr(self, model):
         assert model.__repr__() == "<LinearSVR>"
 
+    @skip_plt
     def test_contour(self, winequality_vd):
         model_test = LinearSVR(
             "model_contour",
@@ -170,6 +180,7 @@ class TestLinearSVR:
             "acceptable_error_margin": 0.1,
         }
 
+    @skip_plt
     def test_get_plot(self, winequality_vd):
         current_cursor().execute("DROP MODEL IF EXISTS model_test_plot")
         model_test = LinearSVR(

--- a/verticapy/tests/vModel/test_lof.py
+++ b/verticapy/tests/vModel/test_lof.py
@@ -31,6 +31,15 @@ from verticapy.connection import current_cursor
 from verticapy.datasets import load_titanic
 from verticapy.learn.neighbors import LocalOutlierFactor
 
+# Matplotlib skip
+import matplotlib
+
+matplotlib_version = matplotlib.__version__
+skip_plt = pytest.mark.skipif(
+    matplotlib_version > "3.5.2",
+    reason="Test skipped on matplotlib version greater than 3.5.2",
+)
+
 set_option("print_info", False)
 
 
@@ -72,6 +81,7 @@ class TestLocalOutlierFactor:
         result = model.get_attributes()
         assert result == ["n_neighbors_", "p_", "n_errors_", "cnt_"]
 
+    @skip_plt
     def test_get_plot(self, model):
         result = model.plot(color=["r", "b"])
         assert len(result.get_default_bbox_extra_artists()) == 9

--- a/verticapy/tests/vModel/test_logistic_regression.py
+++ b/verticapy/tests/vModel/test_logistic_regression.py
@@ -28,6 +28,15 @@ from verticapy.connection import current_cursor
 from verticapy.datasets import load_winequality, load_titanic
 from verticapy.learn.linear_model import LogisticRegression
 
+# Matplotlib skip
+import matplotlib
+
+matplotlib_version = matplotlib.__version__
+skip_plt = pytest.mark.skipif(
+    matplotlib_version > "3.5.2",
+    reason="Test skipped on matplotlib version greater than 3.5.2",
+)
+
 set_option("print_info", False)
 
 
@@ -94,6 +103,7 @@ class TestLogisticRegression:
         assert conf_mat2[0][1] == 602
         assert conf_mat2[1][1] == 391
 
+    @skip_plt
     def test_contour(self, titanic_vd):
         model_test = LogisticRegression(
             "model_contour",
@@ -153,6 +163,7 @@ class TestLogisticRegression:
         assert lift_ch["lift"][900] == pytest.approx(1.0)
         plt.close("all")
 
+    @skip_plt
     def test_get_plot(self, winequality_vd):
         # 1D
         current_cursor().execute("DROP MODEL IF EXISTS model_test_plot")

--- a/verticapy/tests/vModel/test_mca.py
+++ b/verticapy/tests/vModel/test_mca.py
@@ -24,6 +24,15 @@ from verticapy.connection import current_cursor
 from verticapy.datasets import load_market
 from verticapy.learn.decomposition import MCA
 
+# Matplotlib skip
+import matplotlib
+
+matplotlib_version = matplotlib.__version__
+skip_plt = pytest.mark.skipif(
+    matplotlib_version > "3.5.2",
+    reason="Test skipped on matplotlib version greater than 3.5.2",
+)
+
 set_option("print_info", False)
 
 
@@ -115,12 +124,14 @@ class TestMCA:
     def test_get_params(self, model):
         assert model.get_params() == {}
 
+    @skip_plt
     def test_plot(self, model):
         result = model.plot()
         assert len(result.get_default_bbox_extra_artists()) == 8
         result = model.plot(dimensions=(2, 3))
         assert len(result.get_default_bbox_extra_artists()) == 8
 
+    @skip_plt
     def test_plot_var(self, model):
         result = model.plot_var()
         assert len(result.get_default_bbox_extra_artists()) == 62
@@ -131,22 +142,26 @@ class TestMCA:
         result = model.plot_var(dimensions=(2, 3), method="contrib")
         assert len(result.get_default_bbox_extra_artists()) == 62
 
+    @skip_plt
     def test_plot_contrib(self, model):
         result = model.plot_contrib()
         assert len(result.get_default_bbox_extra_artists()) == 114
         result = model.plot_contrib(dimension=2)
         assert len(result.get_default_bbox_extra_artists()) == 114
 
+    @skip_plt
     def test_plot_cos2(self, model):
         result = model.plot_cos2()
         assert len(result.get_default_bbox_extra_artists()) == 111
         result = model.plot_cos2(dimensions=(2, 3))
         assert len(result.get_default_bbox_extra_artists()) == 111
 
+    @skip_plt
     def test_plot_scree(self, model):
         result = model.plot_scree()
         assert len(result.get_default_bbox_extra_artists()) == 113
 
+    @skip_plt
     def test_plot_circle(self, model):
         result = model.plot_circle()
         assert len(result.get_default_bbox_extra_artists()) == 114

--- a/verticapy/tests/vModel/test_naive_bayes.py
+++ b/verticapy/tests/vModel/test_naive_bayes.py
@@ -27,6 +27,15 @@ from verticapy.connection import current_cursor
 from verticapy.datasets import load_winequality, load_titanic, load_iris
 from verticapy.learn.naive_bayes import *
 
+# Matplotlib skip
+import matplotlib
+
+matplotlib_version = matplotlib.__version__
+skip_plt = pytest.mark.skipif(
+    matplotlib_version > "3.5.2",
+    reason="Test skipped on matplotlib version greater than 3.5.2",
+)
+
 set_option("print_info", False)
 
 
@@ -126,6 +135,7 @@ class TestNB:
         assert list(conf_mat1[:, 1]) == [0, 47, 3]
         assert list(conf_mat1[:, 2]) == [0, 3, 47]
 
+    @skip_plt
     def test_contour(self, titanic_vd):
         model_test = NaiveBayes(
             "model_contour",

--- a/verticapy/tests/vModel/test_nearestcentroid.py
+++ b/verticapy/tests/vModel/test_nearestcentroid.py
@@ -30,6 +30,15 @@ from verticapy.connection import current_cursor
 from verticapy.datasets import load_titanic
 from verticapy.learn.neighbors import NearestCentroid
 
+# Matplotlib skip
+import matplotlib
+
+matplotlib_version = matplotlib.__version__
+skip_plt = pytest.mark.skipif(
+    matplotlib_version > "3.5.2",
+    reason="Test skipped on matplotlib version greater than 3.5.2",
+)
+
 set_option("print_info", False)
 
 
@@ -57,6 +66,7 @@ class TestNearestCentroid:
     def test_repr(self, model):
         assert model.__repr__() == "<NearestCentroid>"
 
+    @skip_plt
     def test_contour(self, titanic_vd):
         model_test = NearestCentroid(
             "model_contour",

--- a/verticapy/tests/vModel/test_pca.py
+++ b/verticapy/tests/vModel/test_pca.py
@@ -24,6 +24,15 @@ from verticapy.connection import current_cursor
 from verticapy.datasets import load_winequality
 from verticapy.learn.decomposition import PCA
 
+# Matplotlib skip
+import matplotlib
+
+matplotlib_version = matplotlib.__version__
+skip_plt = pytest.mark.skipif(
+    matplotlib_version > "3.5.2",
+    reason="Test skipped on matplotlib version greater than 3.5.2",
+)
+
 set_option("print_info", False)
 
 
@@ -119,16 +128,19 @@ class TestPCA:
             "scale": False,
         }
 
+    @skip_plt
     def test_plot(self, model):
         result = model.plot()
         assert len(result.get_default_bbox_extra_artists()) == 8
         result = model.plot(dimensions=(2, 3))
         assert len(result.get_default_bbox_extra_artists()) == 8
 
+    @skip_plt
     def test_plot_scree(self, model):
         result = model.plot_scree()
         assert len(result.get_default_bbox_extra_artists()) == 15
 
+    @skip_plt
     def test_plot_circle(self, model):
         result = model.plot_circle()
         assert len(result.get_default_bbox_extra_artists()) == 16

--- a/verticapy/tests/vModel/test_randomforest_classifier.py
+++ b/verticapy/tests/vModel/test_randomforest_classifier.py
@@ -31,6 +31,15 @@ from verticapy.connection import current_cursor
 from verticapy.datasets import load_titanic, load_dataset_cl
 from verticapy.learn.ensemble import RandomForestClassifier
 
+# Matplotlib skip
+import matplotlib
+
+matplotlib_version = matplotlib.__version__
+skip_plt = pytest.mark.skipif(
+    matplotlib_version > "3.5.2",
+    reason="Test skipped on matplotlib version greater than 3.5.2",
+)
+
 set_option("print_info", False)
 
 
@@ -112,6 +121,7 @@ class TestRFC:
         assert list(conf_mat2[:, 1]) == [0, 3, 0]
         assert list(conf_mat2[:, 2]) == [0, 0, 3]
 
+    @skip_plt
     def test_contour(self, titanic_vd):
         model_test = RandomForestClassifier(
             "model_contour",

--- a/verticapy/tests/vModel/test_randomforest_regressor.py
+++ b/verticapy/tests/vModel/test_randomforest_regressor.py
@@ -31,6 +31,15 @@ from verticapy.connection import current_cursor
 from verticapy.datasets import load_titanic, load_winequality, load_dataset_reg
 from verticapy.learn.ensemble import RandomForestRegressor
 
+# Matplotlib skip
+import matplotlib
+
+matplotlib_version = matplotlib.__version__
+skip_plt = pytest.mark.skipif(
+    matplotlib_version > "3.5.2",
+    reason="Test skipped on matplotlib version greater than 3.5.2",
+)
+
 set_option("print_info", False)
 
 
@@ -93,6 +102,7 @@ class TestRFR:
     def test_repr(self, model):
         assert model.__repr__() == "<RandomForestRegressor>"
 
+    @skip_plt
     def test_contour(self, titanic_vd):
         model_test = RandomForestRegressor(
             "model_contour",
@@ -214,6 +224,7 @@ class TestRFR:
             "nbins": 40,
         }
 
+    @skip_plt
     def test_get_plot(self, winequality_vd):
         current_cursor().execute("DROP MODEL IF EXISTS model_test_plot")
         model_test = RandomForestRegressor(

--- a/verticapy/tests/vModel/test_ridge.py
+++ b/verticapy/tests/vModel/test_ridge.py
@@ -28,6 +28,15 @@ from verticapy.connection import current_cursor
 from verticapy.datasets import load_winequality
 from verticapy.learn.linear_model import Ridge
 
+# Matplotlib skip
+import matplotlib
+
+matplotlib_version = matplotlib.__version__
+skip_plt = pytest.mark.skipif(
+    matplotlib_version > "3.5.2",
+    reason="Test skipped on matplotlib version greater than 3.5.2",
+)
+
 set_option("print_info", False)
 
 
@@ -57,6 +66,7 @@ class TestRidge:
     def test_repr(self, model):
         assert model.__repr__() == "<LinearRegression>"
 
+    @skip_plt
     def test_contour(self, winequality_vd):
         model_test = Ridge(
             "model_contour",
@@ -186,6 +196,7 @@ class TestRidge:
             "fit_intercept": True,
         }
 
+    @skip_plt
     def test_get_plot(self, winequality_vd):
         current_cursor().execute("DROP MODEL IF EXISTS model_test_plot")
         model_test = Ridge(

--- a/verticapy/tests/vModel/test_svd.py
+++ b/verticapy/tests/vModel/test_svd.py
@@ -24,6 +24,15 @@ from verticapy.connection import current_cursor
 from verticapy.datasets import load_winequality
 from verticapy.learn.decomposition import SVD
 
+# Matplotlib skip
+import matplotlib
+
+matplotlib_version = matplotlib.__version__
+skip_plt = pytest.mark.skipif(
+    matplotlib_version > "3.5.2",
+    reason="Test skipped on matplotlib version greater than 3.5.2",
+)
+
 set_option("print_info", False)
 
 
@@ -63,16 +72,19 @@ class TestSVD:
 
         assert result_sql == expected_sql
 
+    @skip_plt
     def test_plot(self, model):
         result = model.plot()
         assert len(result.get_default_bbox_extra_artists()) == 8
         result = model.plot(dimensions=(2, 3))
         assert len(result.get_default_bbox_extra_artists()) == 8
 
+    @skip_plt
     def test_plot_scree(self, model):
         result = model.plot_scree()
         assert len(result.get_default_bbox_extra_artists()) == 15
 
+    @skip_plt
     def test_plot_circle(self, model):
         result = model.plot_circle()
         assert len(result.get_default_bbox_extra_artists()) == 16

--- a/verticapy/tests/vModel/test_xgb_classifier.py
+++ b/verticapy/tests/vModel/test_xgb_classifier.py
@@ -36,6 +36,15 @@ from verticapy.datasets import load_titanic, load_dataset_cl
 from verticapy.learn.ensemble import XGBClassifier
 from verticapy._utils._sql._format import clean_query
 
+# Matplotlib skip
+import matplotlib
+
+matplotlib_version = matplotlib.__version__
+skip_plt = pytest.mark.skipif(
+    matplotlib_version > "3.5.2",
+    reason="Test skipped on matplotlib version greater than 3.5.2",
+)
+
 set_option("print_info", False)
 
 
@@ -133,6 +142,7 @@ class TestXGBC:
         assert list(conf_mat2[:, 1]) == [0, 3, 0]
         assert list(conf_mat2[:, 2]) == [0, 0, 3]
 
+    @skip_plt
     def test_contour(self, titanic_vd):
         model_test = XGBClassifier(
             "model_contour",

--- a/verticapy/tests/vModel/test_xgb_regressor.py
+++ b/verticapy/tests/vModel/test_xgb_regressor.py
@@ -37,6 +37,15 @@ from verticapy.connection import current_cursor
 from verticapy.datasets import load_winequality, load_titanic, load_dataset_reg
 from verticapy.learn.ensemble import XGBRegressor
 
+# Matplotlib skip
+import matplotlib
+
+matplotlib_version = matplotlib.__version__
+skip_plt = pytest.mark.skipif(
+    matplotlib_version > "3.5.2",
+    reason="Test skipped on matplotlib version greater than 3.5.2",
+)
+
 set_option("print_info", False)
 
 
@@ -94,6 +103,7 @@ def model(xgbr_data_vd):
     reason="requires vertica 10.1 or higher",
 )
 class TestXGBR:
+    @skip_plt
     def test_contour(self, titanic_vd):
         model_test = XGBRegressor(
             "model_contour",
@@ -477,6 +487,7 @@ class TestXGBR:
         assert tree_1["prediction"][7] in ("-0.720000", "-0.405000")
         assert tree_1["prediction"][8] in ("0.080000", "0.045000")
 
+    @skip_plt
     def test_get_plot(self, winequality_vd):
         current_cursor().execute("DROP MODEL IF EXISTS model_test_plot")
         model_test = XGBRegressor(


### PR DESCRIPTION
 - ignoring old tests to be able to support py3.12
 - old tests are not consistent and soon new tests will cover all the possibilities.