### PR TITLE
Fixing the after-merge test failures on master

### DIFF
--- a/.github/workflows/master-codecov.yml
+++ b/.github/workflows/master-codecov.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        python-version: [3.9, "3.10", 3.11, 3.12]
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
     
     steps:
       - name: Checkout repository
@@ -38,7 +38,17 @@ jobs:
       - name: Run tests
         run: |
           export VP_TEST_USER=dbadmin
-          tox -e py -- --cov=./ --cov-report=xml
+          echo "*** Calling tox based on python-version ***"
+          echo ${{ matrix.python-version }}
+          if ${{ matrix.python-version == '3.9' }}; then
+            tox -e py39 -- --cov=./ --cov-report=xml
+          elif ${{ matrix.python-version == '3.10' }}; then
+            tox -e py310 -- --cov=./ --cov-report=xml
+          elif ${{ matrix.python-version == '3.11' }}; then
+            tox -e py311 -- --cov=./ --cov-report=xml
+          elif ${{ matrix.python-version == '3.12' }}; then
+            tox -e py312 -- --cov=./ --cov-report=xml
+          fi          
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v3
         with:

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,7 @@ envlist = py39,py310,py311,py312
 
 [testenv]
 passenv = *
-commands = pytest
+commands = pytest {posargs}
 deps = 
     -rrequirements-testing.txt
     !py312: tensorflow


### PR DESCRIPTION
The installation of tensorflow must be skipped on master