### PR TITLE
Prototype of collection

### DIFF
--- a/verticapy/performance/vertica/collection_metadata.py
+++ b/verticapy/performance/vertica/collection_metadata.py
@@ -1,0 +1,54 @@
+"""
+Copyright  (c)  2018-2024 Open Text  or  one  of its
+affiliates.  Licensed  under  the   Apache  License,
+Version 2.0 (the  "License"); You  may  not use this
+file except in compliance with the License.
+
+You may obtain a copy of the License at:
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless  required  by applicable  law or  agreed to in
+writing, software  distributed  under the  License is
+distributed on an  "AS IS" BASIS,  WITHOUT WARRANTIES
+OR CONDITIONS OF ANY KIND, either express or implied.
+See the  License for the specific  language governing
+permissions and limitations under the License.
+"""
+import datetime
+import json
+import logging
+import os
+from typing import List
+
+from .file_metadata import FileMetadata
+
+
+class CollectionMetadata:
+    def __init__(self):
+        # List of FileMetadata
+        self.files = []
+        self.date = datetime.datetime.now()
+        self.version = "1.0"
+        self.logger = logging.getLogger(type(self).__name__)
+
+    def add_file(self, file_info: dict) -> None:
+        self.files.append(file_info)
+
+    def get_all_files(self) -> List[FileMetadata]:
+        return self.files
+
+    def to_json(self, output_dir) -> None:
+        if not os.path.exists(output_dir):
+            raise ValueError(f"Directory {output_dir} does not exist")
+
+        fname = os.path.join(output_dir, "metadata.json")
+        with open(fname, "w") as md_file:
+            self._write_json(md_file)
+
+    def _write_json(self, output_file):
+        serialized = {
+            "collection_metadata_version": self.version,
+            "collection_time": str(self.date),
+            "files": [x.to_dict() for x in self.files],
+        }
+        json.dump(serialized, output_file)

--- a/verticapy/performance/vertica/file_metadata.py
+++ b/verticapy/performance/vertica/file_metadata.py
@@ -1,0 +1,44 @@
+"""
+Copyright  (c)  2018-2024 Open Text  or  one  of its
+affiliates.  Licensed  under  the   Apache  License,
+Version 2.0 (the  "License"); You  may  not use this
+file except in compliance with the License.
+
+You may obtain a copy of the License at:
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless  required  by applicable  law or  agreed to in
+writing, software  distributed  under the  License is
+distributed on an  "AS IS" BASIS,  WITHOUT WARRANTIES
+OR CONDITIONS OF ANY KIND, either express or implied.
+See the  License for the specific  language governing
+permissions and limitations under the License.
+"""
+
+
+class FileMetadata:
+    def __init__(
+        self,
+        file_name: str,
+        step_name: str,
+        step_id: int,
+        step_version: str,
+        creation_func_name: str,
+        load_func_name: str,
+    ):
+        self.file_name = file_name
+        self.step_version = step_version
+        self.step_id = step_id
+        self.step_name = step_name
+        self.creation_func_name = creation_func_name
+        self.load_func_name = load_func_name
+
+    def to_dict(self):
+        return {
+            "file_name": self.file_name,
+            "step_name": self.step_name,
+            "step_id": self.step_id,
+            "step_version": self.step_version,
+            "creation_func_name": self.creation_func_name,
+            "load_func_name": self.load_func_name,
+        }

--- a/verticapy/performance/vertica/profile_collector.py
+++ b/verticapy/performance/vertica/profile_collector.py
@@ -1,0 +1,83 @@
+"""
+Copyright  (c)  2018-2024 Open Text  or  one  of its
+affiliates.  Licensed  under  the   Apache  License,
+Version 2.0 (the  "License"); You  may  not use this
+file except in compliance with the License.
+
+You may obtain a copy of the License at:
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless  required  by applicable  law or  agreed to in
+writing, software  distributed  under the  License is
+distributed on an  "AS IS" BASIS,  WITHOUT WARRANTIES
+OR CONDITIONS OF ANY KIND, either express or implied.
+See the  License for the specific  language governing
+permissions and limitations under the License.
+"""
+import logging
+import os
+from typing import List
+import zipfile
+
+from .step00_vertica_version import Step00VerticaVersion
+from .collection_metadata import CollectionMetadata
+from .profile_step_base import ProfileStepBase
+
+
+class ProfileCollector:
+    def __init__(self):
+        self.logger = logging.getLogger("ProfileCollector")
+
+    def collect_all(
+        self, transaction_id: int, statement_id: int, output_dir: str
+    ) -> None:
+        """Returns None
+
+        Calls the following functions for all steps in the collection
+          - setup_collect()
+          - collect()
+          - store()
+
+        """
+        steps = [Step00VerticaVersion()]
+        meta = CollectionMetadata()
+
+        self._run_all_steps(transaction_id, statement_id, steps, meta, output_dir)
+        self._write_metadata(meta, output_dir)
+        self._create_bundle(meta, output_dir)
+
+    def _run_all_steps(
+        self,
+        transaction_id: int,
+        statement_id: int,
+        steps: List[ProfileStepBase],
+        meta: CollectionMetadata,
+        output_dir: str,
+    ) -> None:
+        for step in steps:
+            try:
+                step.setup_collect(
+                    transaction_id=transaction_id,
+                    statement_id=statement_id,
+                    output_dir=output_dir,
+                )
+                step.collect()
+                step.store(meta)
+            except Exception as e:
+                # Someday we can improve better exception handling
+                # Like raising custom errors when the step cannot be completed
+                self.logger.error(f"Caughht exception {e} running step {step}")
+                raise
+
+    def _write_metadata(self, meta: CollectionMetadata, output_dir: str) -> None:
+        meta.to_json(output_dir=output_dir)
+
+    def _create_bundle(self, meta: CollectionMetadata, output_dir: str):
+        self.logger.info("Called _create_bundle")
+        bundle_file_name = os.path.join(output_dir, "profile.zip")
+        with zipfile.ZipFile(bundle_file_name, mode="w") as zfile:
+            md_full_path = os.path.join(output_dir, "metadata.json")
+            zfile.write(md_full_path, arcname="metadata.json")
+            for f in meta.get_all_files():
+                full_path = os.path.join(output_dir, f.file_name)
+                zfile.write(full_path, arcname=f.file_name)

--- a/verticapy/performance/vertica/profile_step_base.py
+++ b/verticapy/performance/vertica/profile_step_base.py
@@ -1,0 +1,50 @@
+"""
+Copyright  (c)  2018-2024 Open Text  or  one  of its
+affiliates.  Licensed  under  the   Apache  License,
+Version 2.0 (the  "License"); You  may  not use this
+file except in compliance with the License.
+
+You may obtain a copy of the License at:
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless  required  by applicable  law or  agreed to in
+writing, software  distributed  under the  License is
+distributed on an  "AS IS" BASIS,  WITHOUT WARRANTIES
+OR CONDITIONS OF ANY KIND, either express or implied.
+See the  License for the specific  language governing
+permissions and limitations under the License.
+"""
+
+from abc import ABC, abstractmethod
+from .collection_metadata import CollectionMetadata
+
+
+class ProfileStepBase(ABC):
+    @abstractmethod
+    def setup_collect(
+        self, transaction_id: int, statement_id: int, output_dir: str
+    ) -> None:
+        """Sets up collection"""
+
+    @abstractmethod
+    def collect(self) -> None:
+        """Returns None
+
+        Runs the operation associated with this
+        """
+
+    @abstractmethod
+    def store(self, metadata: CollectionMetadata) -> None:
+        pass
+
+    @abstractmethod
+    def setup_load(self, collection_metadata: dict) -> None:
+        pass
+
+    @abstractmethod
+    def load(self) -> None:
+        pass
+
+    @abstractmethod
+    def analyze(self) -> None:
+        pass

--- a/verticapy/performance/vertica/step00_vertica_version.py
+++ b/verticapy/performance/vertica/step00_vertica_version.py
@@ -1,0 +1,91 @@
+"""
+Copyright  (c)  2018-2024 Open Text  or  one  of its
+affiliates.  Licensed  under  the   Apache  License,
+Version 2.0 (the  "License"); You  may  not use this
+file except in compliance with the License.
+
+You may obtain a copy of the License at:
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless  required  by applicable  law or  agreed to in
+writing, software  distributed  under the  License is
+distributed on an  "AS IS" BASIS,  WITHOUT WARRANTIES
+OR CONDITIONS OF ANY KIND, either express or implied.
+See the  License for the specific  language governing
+permissions and limitations under the License.
+"""
+import logging
+import os
+
+from .profile_step_base import ProfileStepBase
+
+from verticapy.core.vdataframe import vDataFrame
+from verticapy._utils._sql._vertica_version import vertica_version
+from .collection_metadata import CollectionMetadata
+from .file_metadata import FileMetadata
+from .step_info import StepId
+
+
+class Step00VerticaVersion(ProfileStepBase):
+    def __init__(self):
+        self.transaction_id = None
+        self.statement_id = None
+        self.output_dir = None
+        self.version_vdf = None
+        self.step_name = type(self).__name__
+        self.step_id = StepId.VERTICA_VERSION.value
+        self.step_version = "1.0"
+        self.logger = logging.getLogger(self.step_name)
+
+    def setup_collect(
+        self, transaction_id: int, statement_id: int, output_dir: str
+    ) -> None:
+        # setup_collect is effectively a no-op.
+        # Step00VerticaVersion is an exceptional step
+        # where the output doesn't actually require the statement_id or
+        # the transaction_id.
+        self.transaction_id = transaction_id
+        self.statement_id = statement_id
+        self.output_dir = output_dir
+
+    def collect(self) -> None:
+        version_tuple = vertica_version()
+        # vDataFrame can only be created with two-dimensional objects
+        version_table = [version_tuple]
+        self.version_vdf = vDataFrame(version_table)
+
+    def store(self, metadata: CollectionMetadata) -> None:
+        if self.version_vdf is None:
+            raise ValueError("Step00 store expects collect to be called first")
+
+        pandas = self.version_vdf.to_pandas()
+        output_path = os.path.join(self.output_dir, "step00_vertica_version.parquet")
+        pandas.to_parquet(path=output_path, compression="gzip")
+
+        self.logger.info(
+            "Wrote output to %s parquet file",
+        )
+        self._update_metadata(output_path, metadata)
+
+    def _update_metadata(self, output_path: str, metadata: CollectionMetadata) -> None:
+        basename = os.path.basename(output_path)
+        metadata.add_file(self._get_file_metadata(basename))
+
+    def _get_file_metadata(self, file_name: str) -> FileMetadata:
+        return FileMetadata(
+            file_name=file_name,
+            step_name=self.step_name,
+            step_id=self.step_id,
+            step_version=self.step_version,
+            creation_func_name="store",
+            load_func_name="load",
+        )
+
+    def setup_load(self, collection_metadata: dict) -> None:
+        pass
+
+    def load(self) -> None:
+        pass
+
+    def analyze(self) -> None:
+        pass

--- a/verticapy/performance/vertica/step_info.py
+++ b/verticapy/performance/vertica/step_info.py
@@ -14,7 +14,13 @@ OR CONDITIONS OF ANY KIND, either express or implied.
 See the  License for the specific  language governing
 permissions and limitations under the License.
 """
-from verticapy.performance.vertica.qprof import QueryProfiler
-from verticapy.performance.vertica.collection_metadata import CollectionMetadata
-from verticapy.performance.vertica.step00_vertica_version import Step00VerticaVersion
-from verticapy.performance.vertica.profile_collector import ProfileCollector
+
+from enum import Enum
+
+
+class StepId(Enum):
+    VERTICA_VERSION = 0
+    QUERY_TEXT = 1
+    QUERY_DURACTION = 2
+    QUERY_EXECUTION_STEPS = 3
+    # ... etc for all the qprof steps

--- a/verticapy/tests_new/performance/vertica/test_collection_simple.py
+++ b/verticapy/tests_new/performance/vertica/test_collection_simple.py
@@ -1,0 +1,94 @@
+"""
+Copyright  (c)  2018-2024 Open Text  or  one  of its
+affiliates.  Licensed  under  the   Apache  License,
+Version 2.0 (the  "License"); You  may  not use this
+file except in compliance with the License.
+
+You may obtain a copy of the License at:
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless  required  by applicable  law or  agreed to in
+writing, software  distributed  under the  License is
+distributed on an  "AS IS" BASIS,  WITHOUT WARRANTIES
+OR CONDITIONS OF ANY KIND, either express or implied.
+See the  License for the specific  language governing
+permissions and limitations under the License.
+"""
+import logging
+import os
+import pandas
+import zipfile
+
+from verticapy.performance.vertica import (
+    Step00VerticaVersion,
+    CollectionMetadata,
+    ProfileCollector,
+)
+
+_module_logger = None
+
+
+def get_logger():
+    global _module_logger
+    _module_logger = (
+        _module_logger
+        if _module_logger is not None
+        else logging.getLogger("TestCollectionSimple")
+    )
+    return _module_logger
+
+
+class TestCollectionSimple:
+    def test_collect_version_info(self, tmp_path):
+        logger = get_logger()
+        logger.info("Testing vertica version collection")
+        md = CollectionMetadata()
+        step = Step00VerticaVersion()
+        step.setup_collect(transaction_id=123, statement_id=4, output_dir=str(tmp_path))
+
+        step.collect()
+        step.store(md)
+
+        all_files = md.get_all_files()
+        assert len(all_files) == 1
+
+        file_meta = all_files[0]
+        file_info = file_meta.to_dict()
+        logging.info(f"FileMetadata serialized is: {file_info}")
+        assert "file_name" in file_info
+        assert "step_version" in file_info
+        assert file_info["step_name"] == "Step00VerticaVersion"
+
+        output_file = os.path.join(tmp_path, file_info["file_name"])
+        assert os.path.exists(output_file)
+
+        df = pandas.read_parquet(output_file)
+        assert df.shape[0] == 1
+        assert df.shape[1] == 3 or df.shape[1] == 4
+        row = df.iloc(0)
+        print(f"Here is a row: {row[0]['col0']}, {row[0]['col1']}, {row[0]['col2']}")
+        assert row[0]["col0"] >= 23
+        assert row[0]["col1"] >= 0
+        assert row[0]["col2"] >= 0
+
+    def test_collect_all(self, tmp_path):
+        p = ProfileCollector()
+        p.collect_all(transaction_id=123, statement_id=4, output_dir=str(tmp_path))
+        expected_output = tmp_path / "profile.zip"
+        assert os.path.exists(expected_output)
+        with zipfile.ZipFile(expected_output, "r") as zfile:
+            self._check_zipfile_info(zfile)
+
+    def _check_zipfile_info(self, zfile: zipfile.ZipFile) -> None:
+        foundMetadata = False
+        foundStep00 = False
+        all_file_names = []
+        for i, zinfo in enumerate(zfile.infolist()):
+            print(f"Item {i} is {zinfo}")
+            all_file_names.append(zinfo.filename)
+            if zinfo.filename.startswith("step00_"):
+                foundStep00 = True
+            if zinfo.filename == "metadata.json":
+                foundMetadata = True
+        assert foundMetadata, f"Did not find metadata.json in {all_file_names}"
+        assert foundStep00, f"Did not find step00_* in {all_file_names}"


### PR DESCRIPTION
# VER-90670

This PR contains a prototype of what collecting resources as a parquet files looks like.

Key Features
* Each qprof collection activity is called a "step", broken out into its own class
* The collector iterates over steps to produce parquet files
* The collector generates a metadata.json file
* The collector bundles the metadata.json and the parquet files into a single output file
* The process is testable: each step is testable and so is the overall output

Didn't build yet, but know that we want to build
* The collect_all function should return a URL that allows the user to download files
* The collect_all function should infer a browser temp directory when using a jupyter notebook
* Better docstrings to describe the different pieces
* Continue extending tests


Next steps
* Discuss the design with everyone, ensure that we agree on the way forward
* Integrate with qprof class
