### PR TITLE
Add a .gitignore file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,28 @@
+# Copyright  (c)  2018-2024 Open Text  or  one  of its
+# affiliates.  Licensed  under  the   Apache  License,
+# Version 2.0 (the  "License"); You  may  not use this
+# file except in compliance with the License.
+#
+# You may obtain a copy of the License at:
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless  required  by applicable  law or  agreed to in
+# writing, software  distributed  under the  License is
+# distributed on an  "AS IS" BASIS,  WITHOUT WARRANTIES
+# OR CONDITIONS OF ANY KIND, either express or implied.
+# See the  License for the specific  language governing
+# permissions and limitations under the License.
+
+
+# Ignore all pycache directories
+**/__pycache__
+
+# Ignore emacs backup files
+*~
+
+# Build and dist directories aren't
+# tracked by source control
+
+build/
+dist/
+verticapy.egg-info/


### PR DESCRIPTION
## VER-91173

Add a .gitignore file to the verticapy project to simplify source control.

Ignoring the __pytest__ directories makes `git status` output easier to understand.