### PR TITLE
Sphinx - RST Files - Benchmark update

### DIFF
--- a/docs/source/benchmarks_arima.rst
+++ b/docs/source/benchmarks_arima.rst
@@ -136,10 +136,10 @@ Browse throught the different tabs to see the results:
           width = 600,
           height = 500,
           )
-      fig.write_html("/project/data/VerticaPy/docs/figures/benchmark_arima_train_10k.html")
+      fig.write_html("SPHINX_DIRECTORY/figures/benchmark_arima_train_10k.html")
 
     .. raw:: html
-      :file: /project/data/VerticaPy/docs/figures/benchmark_arima_train_10k.html
+      :file: SPHINX_DIRECTORY/figures/benchmark_arima_train_10k.html
 
   .. tab:: Prediction Run Time
 
@@ -166,10 +166,10 @@ Browse throught the different tabs to see the results:
           width = 600,
           height = 500,
           )
-      fig.write_html("/project/data/VerticaPy/docs/figures/benchmark_arima_prediction_10k.html")
+      fig.write_html("SPHINX_DIRECTORY/figures/benchmark_arima_prediction_10k.html")
 
     .. raw:: html
-      :file: /project/data/VerticaPy/docs/figures/benchmark_arima_prediction_10k.html
+      :file: SPHINX_DIRECTORY/figures/benchmark_arima_prediction_10k.html
 
 
   .. tab:: Mean Squared Error
@@ -197,10 +197,10 @@ Browse throught the different tabs to see the results:
           width = 600,
           height = 500,
           )
-      fig.write_html("/project/data/VerticaPy/docs/figures/benchmark_arima_mse_10k.html")
+      fig.write_html("SPHINX_DIRECTORY/figures/benchmark_arima_mse_10k.html")
 
     .. raw:: html
-      :file: /project/data/VerticaPy/docs/figures/benchmark_arima_mse_10k.html
+      :file: SPHINX_DIRECTORY/figures/benchmark_arima_mse_10k.html
 
 
 .. tab:: 100K
@@ -230,10 +230,10 @@ Browse throught the different tabs to see the results:
           width = 600,
           height = 500,
           )
-      fig.write_html("/project/data/VerticaPy/docs/figures/benchmark_arima_train_100k.html")
+      fig.write_html("SPHINX_DIRECTORY/figures/benchmark_arima_train_100k.html")
 
     .. raw:: html
-      :file: /project/data/VerticaPy/docs/figures/benchmark_arima_train_100k.html
+      :file: SPHINX_DIRECTORY/figures/benchmark_arima_train_100k.html
 
   .. tab:: Prediction Run Time
 
@@ -260,10 +260,10 @@ Browse throught the different tabs to see the results:
           width = 600,
           height = 500,
           )
-      fig.write_html("/project/data/VerticaPy/docs/figures/benchmark_arima_prediction_100k.html")
+      fig.write_html("SPHINX_DIRECTORY/figures/benchmark_arima_prediction_100k.html")
 
     .. raw:: html
-      :file: /project/data/VerticaPy/docs/figures/benchmark_arima_prediction_100k.html
+      :file: SPHINX_DIRECTORY/figures/benchmark_arima_prediction_100k.html
 
 
   .. tab:: Mean Squared Error
@@ -291,10 +291,10 @@ Browse throught the different tabs to see the results:
           width = 600,
           height = 500,
           )
-      fig.write_html("/project/data/VerticaPy/docs/figures/benchmark_arima_mse_100k.html")
+      fig.write_html("SPHINX_DIRECTORY/figures/benchmark_arima_mse_100k.html")
 
     .. raw:: html
-      :file: /project/data/VerticaPy/docs/figures/benchmark_arima_mse_100k.html
+      :file: SPHINX_DIRECTORY/figures/benchmark_arima_mse_100k.html
 
 
 .. tab:: 1M
@@ -324,10 +324,10 @@ Browse throught the different tabs to see the results:
           width = 600,
           height = 500,
           )
-      fig.write_html("/project/data/VerticaPy/docs/figures/benchmark_arima_train_1m.html")
+      fig.write_html("SPHINX_DIRECTORY/figures/benchmark_arima_train_1m.html")
 
     .. raw:: html
-      :file: /project/data/VerticaPy/docs/figures/benchmark_arima_train_1m.html
+      :file: SPHINX_DIRECTORY/figures/benchmark_arima_train_1m.html
 
   .. tab:: Prediction Run Time
 
@@ -354,10 +354,10 @@ Browse throught the different tabs to see the results:
           width = 600,
           height = 500,
           )
-      fig.write_html("/project/data/VerticaPy/docs/figures/benchmark_arima_prediction_1m.html")
+      fig.write_html("SPHINX_DIRECTORY/figures/benchmark_arima_prediction_1m.html")
 
     .. raw:: html
-      :file: /project/data/VerticaPy/docs/figures/benchmark_arima_prediction_1m.html
+      :file: SPHINX_DIRECTORY/figures/benchmark_arima_prediction_1m.html
 
 
   .. tab:: Mean Squared Error
@@ -385,10 +385,10 @@ Browse throught the different tabs to see the results:
           width = 600,
           height = 500,
           )
-      fig.write_html("/project/data/VerticaPy/docs/figures/benchmark_arima_mse_1m.html")
+      fig.write_html("SPHINX_DIRECTORY/figures/benchmark_arima_mse_1m.html")
 
     .. raw:: html
-      :file: /project/data/VerticaPy/docs/figures/benchmark_arima_mse_1m.html
+      :file: SPHINX_DIRECTORY/figures/benchmark_arima_mse_1m.html
 
 
 
@@ -419,10 +419,10 @@ Browse throught the different tabs to see the results:
           width = 600,
           height = 500,
           )
-      fig.write_html("/project/data/VerticaPy/docs/figures/benchmark_arima_train_10m.html")
+      fig.write_html("SPHINX_DIRECTORY/figures/benchmark_arima_train_10m.html")
 
     .. raw:: html
-      :file: /project/data/VerticaPy/docs/figures/benchmark_arima_train_10m.html
+      :file: SPHINX_DIRECTORY/figures/benchmark_arima_train_10m.html
 
   .. tab:: Prediction Run Time
 
@@ -449,10 +449,10 @@ Browse throught the different tabs to see the results:
           width = 600,
           height = 500,
           )
-      fig.write_html("/project/data/VerticaPy/docs/figures/benchmark_arima_prediction_10m.html")
+      fig.write_html("SPHINX_DIRECTORY/figures/benchmark_arima_prediction_10m.html")
 
     .. raw:: html
-      :file: /project/data/VerticaPy/docs/figures/benchmark_arima_prediction_10m.html
+      :file: SPHINX_DIRECTORY/figures/benchmark_arima_prediction_10m.html
 
 
   .. tab:: Mean Squared Error
@@ -480,10 +480,10 @@ Browse throught the different tabs to see the results:
           width = 600,
           height = 500,
           )
-      fig.write_html("/project/data/VerticaPy/docs/figures/benchmark_arima_mse_10m.html")
+      fig.write_html("SPHINX_DIRECTORY/figures/benchmark_arima_mse_10m.html")
 
     .. raw:: html
-      :file: /project/data/VerticaPy/docs/figures/benchmark_arima_mse_10m.html
+      :file: SPHINX_DIRECTORY/figures/benchmark_arima_mse_10m.html
 
 
 
@@ -516,10 +516,10 @@ Browse throught the different tabs to see the results:
           width = 600,
           height = 500,
           )
-      fig.write_html("/project/data/VerticaPy/docs/figures/benchmark_arima_train_100m.html")
+      fig.write_html("SPHINX_DIRECTORY/figures/benchmark_arima_train_100m.html")
 
     .. raw:: html
-      :file: /project/data/VerticaPy/docs/figures/benchmark_arima_train_100m.html
+      :file: SPHINX_DIRECTORY/figures/benchmark_arima_train_100m.html
 
   .. tab:: Prediction Run Time
 
@@ -546,10 +546,10 @@ Browse throught the different tabs to see the results:
           width = 600,
           height = 500,
           )
-      fig.write_html("/project/data/VerticaPy/docs/figures/benchmark_arima_prediction_100m.html")
+      fig.write_html("SPHINX_DIRECTORY/figures/benchmark_arima_prediction_100m.html")
 
     .. raw:: html
-      :file: /project/data/VerticaPy/docs/figures/benchmark_arima_prediction_100m.html
+      :file: SPHINX_DIRECTORY/figures/benchmark_arima_prediction_100m.html
 
 
   .. tab:: Mean Squared Error
@@ -577,9 +577,9 @@ Browse throught the different tabs to see the results:
           width = 600,
           height = 500,
           )
-      fig.write_html("/project/data/VerticaPy/docs/figures/benchmark_arima_mse_100m.html")
+      fig.write_html("SPHINX_DIRECTORY/figures/benchmark_arima_mse_100m.html")
 
     .. raw:: html
-      :file: /project/data/VerticaPy/docs/figures/benchmark_arima_mse_100m.html
+      :file: SPHINX_DIRECTORY/figures/benchmark_arima_mse_100m.html
 
 

--- a/docs/source/benchmarks_naive.rst
+++ b/docs/source/benchmarks_naive.rst
@@ -50,24 +50,11 @@ Dataset
   .. list-table:: 
       :header-rows: 1
 
-      * - # of Rows
+      * - No. of Rows
+        - No. of Columns
       * - 25 M
+        - 106
 
-
-  .. ipython:: python
-    :suppress:
-
-    import plotly.express as px
-    col_des = ['No. of Columns', 'No. of Feature Columns']
-    vals = [106, 105] 
-    df = pd.DataFrame({'des': col_des, 'vals': vals})
-    fig = px.bar(df, x='des', y='vals', 
-      color='des')
-    fig.update_layout(xaxis_title=None, yaxis_title=None, showlegend=False)
-    fig.write_html("SPHINX_DIRECTORY/figures/benchmark_naive_amazon_data_cols.html")
-
-  .. raw:: html
-    :file: SPHINX_DIRECTORY/figures/benchmark_naive_amazon_data_cols.html
 
   Datatypes of data: :bdg-primary-line:`Float`
 
@@ -233,9 +220,9 @@ Comparison
 
       import plotly.graph_objects as go
       data = {
-          'Metric': ['Train model', 'Prediction', 'Accuracy', 'AUC'],
-          'Spark': [145.70, 1095.79, 150.55, 146.58],
-          'Vertica': [9.08, 207.56, 0.99, 2.19]
+          'Metric': ['Train model', 'Prediction'],
+          'Spark': [145.70, 1095.79],
+          'Vertica': [9.08, 207.56]
       }
       fig = go.Figure()
       bar_width = 0.22  # Set the width of each bar
@@ -365,9 +352,9 @@ Comparison
 
       import plotly.graph_objects as go
       data = {
-          'Metric': ['Train model', 'Prediction', 'Accuracy', 'AUC'],
-          'Spark': [69.16, 1134.03, 64.46, 63.70],
-          'Vertica': [4.83, 103.90, 0.74, 0.78]
+          'Metric': ['Train model', 'Prediction'],
+          'Spark': [69.16, 1134.03],
+          'Vertica': [4.83, 103.90]
       }
       fig = go.Figure()
       bar_width = 0.22  # Set the width of each bar

--- a/docs/source/benchmarks_random_forest.rst
+++ b/docs/source/benchmarks_random_forest.rst
@@ -50,24 +50,10 @@ Dataset
   .. list-table:: 
       :header-rows: 1
 
-      * - # of Rows
+      * - No. of Rows
+        - No. of Columns
       * - 25 M
-
-
-  .. ipython:: python
-    :suppress:
-
-    import plotly.express as px
-    col_des = ['No. of Columns', 'No. of Feature Columns']
-    vals = [106, 105] 
-    df = pd.DataFrame({'des': col_des, 'vals': vals})
-    fig = px.bar(df, x='des', y='vals', 
-      color='des')
-    fig.update_layout(xaxis_title=None, yaxis_title=None, showlegend=False)
-    fig.write_html("SPHINX_DIRECTORY/figures/benchmark_rf_amazon_data_cols.html")
-
-  .. raw:: html
-    :file: SPHINX_DIRECTORY/figures/benchmark_rf_amazon_data_cols.html
+        - 106
 
   Datatypes of data: :bdg-primary-line:`Float`
 
@@ -491,22 +477,12 @@ Dataset
 
 
 
-  .. ipython:: python
-    :suppress:
+  .. list-table:: 
+      :header-rows: 1
 
-    import plotly.express as px
-    col_des = ['No. of Columns', 'No. of Feature Columns']
-    vals = [106, 105] 
-    df = pd.DataFrame({'des': col_des, 'vals': vals})
-    fig = px.bar(df, x='des', y='vals', 
-      color='des')
-    fig.update_layout(xaxis_title=None, yaxis_title=None, showlegend=False)
-    fig.write_html("SPHINX_DIRECTORY/figures/benchmark_rf_amazon_data_cols.html")
-
-  .. raw:: html
-    :file: SPHINX_DIRECTORY/figures/benchmark_rf_amazon_data_cols.html
-
-
+      * - No. of Columns
+      * - 106
+      
   Datatypes of data: :bdg-primary-line:`Float`
 
 .. note::

--- a/docs/source/benchmarks_xgboost.rst
+++ b/docs/source/benchmarks_xgboost.rst
@@ -79,20 +79,11 @@ Datasets
     :file: SPHINX_DIRECTORY/figures/benchmark_xgboost_higgs_data.html
 
 
-  .. ipython:: python
-    :suppress:
+  .. list-table:: 
+      :header-rows: 1
 
-    import plotly.express as px
-    col_des = ['No. of Columns', 'No. of Feature Columns']
-    vals = [29, 28] 
-    df = pd.DataFrame({'des': col_des, 'vals': vals})
-    fig = px.bar(df, x='des', y='vals', 
-      color='des')
-    fig.update_layout(xaxis_title=None, yaxis_title=None,showlegend=False)
-    fig.write_html("SPHINX_DIRECTORY/figures/benchmark_xgboost_higgs_data_cols.html")
-
-  .. raw:: html
-    :file: SPHINX_DIRECTORY/figures/benchmark_xgboost_higgs_data_cols.html
+      * - No. of Columns
+      * - 29
 
 
   Datatypes of data: :bdg-primary-line:`Float`
@@ -120,21 +111,11 @@ Datasets
 
 
 
-  .. ipython:: python
-    :suppress:
+  .. list-table:: 
+      :header-rows: 1
 
-    import plotly.express as px
-    col_des = ['No. of Columns', 'No. of Feature Columns']
-    vals = [106, 105] 
-    df = pd.DataFrame({'des': col_des, 'vals': vals})
-    fig = px.bar(df, x='des', y='vals', 
-      color='des')
-    fig.update_layout(xaxis_title=None, yaxis_title=None, showlegend=False)
-    fig.write_html("SPHINX_DIRECTORY/figures/benchmark_xgboost_amazon_data_cols.html")
-
-  .. raw:: html
-    :file: SPHINX_DIRECTORY/figures/benchmark_xgboost_amazon_data_cols.html
-
+      * - No. of Columns
+      * - 106
 
   Datatypes of data: :bdg-primary-line:`Float`
 
@@ -691,13 +672,16 @@ Dataset
 
 **Amazon**
 
-Size: 25 M
+.. list-table:: 
+    :header-rows: 1
 
-Number of columns : 106
+    * - No. of Rows
+      - No. of Columns
+    * - 25 M
+      - 106
 
-Datatypes of data: Float
+Datatypes of data: :bdg-primary-line:`Float`
 
-Number of feature columns: 105
 
 .. note::
 


### PR DESCRIPTION
Addressed some feedback comments about the Benchmark Doc Page
- Separated data sizes for ARIMA into 10K, 100K etc
- Removed bar chart to represent no. of columns
- Removed time chart for Accuracy and AUC for naive bayes and Xgboost.
- Fixed units for MSE for ARIMA