### PR TITLE
Reshaping the template of the Issues tab

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Bug Reports (and other issues)
+    url: https://github.com/vertica/VerticaPy/discussions/categories/potential-bug
+    about: Possible bugs can be raised as a "Potential bug" discussion.
+  - name: Feature Request / Enhancement
+    url: https://github.com/vertica/VerticaPy/discussions/categories/ideas
+    about: Feature requests can be raised as an "Ideas" discussion.

--- a/.github/ISSUE_TEMPLATE/issue.yml
+++ b/.github/ISSUE_TEMPLATE/issue.yml
@@ -4,7 +4,7 @@ description: >-
 body:
   - type: textarea
     attributes:
-      label: What is the observed bug, the requested behavior-change, or the new feature?
-      description: A clear and concise description.
+      label: What is the requested change?
+      description: A clear and concise description of the observed bug or the requested new feature/behavior.
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/issue.yml
+++ b/.github/ISSUE_TEMPLATE/issue.yml
@@ -1,0 +1,10 @@
+name: Trackable Change
+description: >-
+  Please only use this, if you've been advised to do so after a discussion.
+body:
+  - type: textarea
+    attributes:
+      label: What is the observed bug, the requested behavior-change, or the new feature?
+      description: A clear and concise description.
+    validations:
+      required: true


### PR DESCRIPTION
Per a request from @oualib, I investigate how we can reshape our "Issues" tab. The changes proposed in this PR is going to provide three options when trying to create a new issue:

- Trackable Change: This will create a new issue similar to what we had before.
- Bug Reports (and other issues): This will navigate the page to the "Potential bug" category in the "Discussion" tab.
- Feature Request / Enhancement: This will navigate the page to the "Ideas" category in the "Discussion" tab.

This PR will resolve issue #1098.