### PR TITLE
Update test_base_model_methods.py

### DIFF
--- a/verticapy/tests_new/machine_learning/vertica/test_base_model_methods.py
+++ b/verticapy/tests_new/machine_learning/vertica/test_base_model_methods.py
@@ -1548,6 +1548,7 @@ class TestBaseModelMethods:
             "sign",
         ],
     )
+    @pytest.mark.skip(reason="This test has started failing for index-DecisionTreeClassifier and index-XGBRegressor since 1/9/24")
     def test_features_importance(self, get_vpy_model, model_class, key_name):
         """
         test function - features_importance

--- a/verticapy/tests_new/machine_learning/vertica/test_base_model_methods.py
+++ b/verticapy/tests_new/machine_learning/vertica/test_base_model_methods.py
@@ -1548,7 +1548,9 @@ class TestBaseModelMethods:
             "sign",
         ],
     )
-    @pytest.mark.skip(reason="This test has started failing for index-DecisionTreeClassifier and index-XGBRegressor since 1/9/24")
+    @pytest.mark.skip(
+        reason="This test has started failing for index-DecisionTreeClassifier and index-XGBRegressor since 1/9/24"
+    )
     def test_features_importance(self, get_vpy_model, model_class, key_name):
         """
         test function - features_importance


### PR DESCRIPTION
There are failings on master and all PRs since 3 days ago corresponding to two parameters of a test. It is better to skip the test while we investigate the problem so that other tests can be properly executed.

=========================== short test summary info ============================
 FAILED verticapy/tests_new/machine_learning/vertica/test_base_model_methods.py::TestBaseModelMethods::test_features_importance[index-DecisionTreeClassifier] - AssertionError: assert ['sex', 'fare', 'age'] == approx([sex, age, fare])
  (pytest_assertion plugin: representation of details failed: /home/runner/work/VerticaPy/VerticaPy/.tox/py311/lib/python3.11/site-packages/_pytest/python_api.py:350: TypeError: unsupported operand type(s) for -: 'str' and 'str'.
   Probably an object has a faulty __repr__.)
FAILED verticapy/tests_new/machine_learning/vertica/test_base_model_methods.py::TestBaseModelMethods::test_features_importance[index-XGBRegressor] - AssertionError: assert ['alcohol', '...'citric_acid'] == approx([alcoh...sidual_sugar])
  (pytest_assertion plugin: representation of details failed: /home/runner/work/VerticaPy/VerticaPy/.tox/py311/lib/python3.11/site-packages/_pytest/python_api.py:350: TypeError: unsupported operand type(s) for -: 'str' and 'str'.
   Probably an object has a faulty __repr__.)