### PR TITLE
Plotly Scatter Plot - bugfix + Unit Test update

### DIFF
--- a/verticapy/plotting/_plotly/scatter.py
+++ b/verticapy/plotting/_plotly/scatter.py
@@ -95,9 +95,9 @@ class ScatterPlot(PlotlyBase):
             data=data,
             columns=columns,
         )
+        df[column_names[0]] = df[column_names[0]].astype(float)
+        df[column_names[1]] = df[column_names[1]].astype(float)
         if self.data.get("s") is not None:
-            df[column_names[0]] = df[column_names[0]].astype(float)
-            df[column_names[1]] = df[column_names[1]].astype(float)
             df[self.layout["size"]] = df[self.layout["size"]].astype(float)
             min_value = df[self.layout["size"]].min()
             max_value = df[self.layout["size"]].max()
@@ -125,6 +125,7 @@ class ScatterPlot(PlotlyBase):
             )
             fig.update_layout(**self._update_dict(self.init_style, style_kwargs))
         elif self.data["X"].shape[1] == 3:
+            df[column_names[2]] = df[column_names[2]].astype(float)
             fig = px.scatter_3d(
                 df,
                 x=column_names[0],

--- a/verticapy/tests_new/plotting/base_test_files.py
+++ b/verticapy/tests_new/plotting/base_test_files.py
@@ -76,6 +76,7 @@ def get_zaxis_label(obj):
         return obj.options["zAxis"].title.text
     return None
 
+
 def get_xaxis_data_type(obj):
     """
     Get x-axis data type for given plotting object
@@ -84,11 +85,12 @@ def get_xaxis_data_type(obj):
         # Need to figure out how to get the data type for Matplotlib
         return None
     if isinstance(obj, go.Figure):
-        return obj.data[0]['x'].dtype
+        return obj.data[0]["x"].dtype
     if isinstance(obj, Highchart):
         # Need to figure out how to get the data type for Highcharts
         return None
     return None
+
 
 def get_yaxis_data_type(obj):
     """
@@ -98,11 +100,12 @@ def get_yaxis_data_type(obj):
         # Need to figure out how to get the data type for Matplotlib
         return None
     if isinstance(obj, go.Figure):
-        return obj.data[0]['y'].dtype
+        return obj.data[0]["y"].dtype
     if isinstance(obj, Highchart):
         # Need to figure out how to get the data type for Highcharts
         return None
     return None
+
 
 def get_zaxis_data_type(obj):
     """
@@ -112,11 +115,12 @@ def get_zaxis_data_type(obj):
         # Need to figure out how to get the data type for Matplotlib
         return None
     if isinstance(obj, go.Figure):
-        return obj.data[0]['z'].dtype
+        return obj.data[0]["z"].dtype
     if isinstance(obj, Highchart):
         # Need to figure out how to get the data type for Highcharts
         return None
     return None
+
 
 def get_width(obj):
     """
@@ -1436,8 +1440,10 @@ class ScatterVDF2DPlot(BasicPlotTests):
         # Arrange
         # Act
         # Assert - checking if correct object created
-        assert np.issubdtype(get_xaxis_data_type(self.result), float), "Wrong data type for X axis"
-        
+        assert np.issubdtype(
+            get_xaxis_data_type(self.result), float
+        ), "Wrong data type for X axis"
+
     def test_data_type_for_y_axis(self):
         """
         Test if data type for Y axis is float
@@ -1445,8 +1451,9 @@ class ScatterVDF2DPlot(BasicPlotTests):
         # Arrange
         # Act
         # Assert - checking if correct object created
-        assert np.issubdtype(get_yaxis_data_type(self.result), float), "Wrong data type for Y axis"
-
+        assert np.issubdtype(
+            get_yaxis_data_type(self.result), float
+        ), "Wrong data type for Y axis"
 
     @pytest.mark.parametrize("attributes", [["Z", 50, 2], [None, 1000, 4]])
     def test_properties_output_type_for_all_options(
@@ -1515,8 +1522,9 @@ class ScatterVDF3DPlot(BasicPlotTests):
         # Arrange
         # Act
         # Assert - checking if correct object created
-        assert np.issubdtype(get_yaxis_data_type(self.result), float), "Wrong data type for Y axis"
-
+        assert np.issubdtype(
+            get_yaxis_data_type(self.result), float
+        ), "Wrong data type for Y axis"
 
 
 class VDCSpiderPlot:

--- a/verticapy/tests_new/plotting/base_test_files.py
+++ b/verticapy/tests_new/plotting/base_test_files.py
@@ -20,17 +20,17 @@ import pytest
 import numpy as np
 
 # Vertica
-from verticapy.learn.model_selection import elbow
-from verticapy.learn.ensemble import RandomForestClassifier
-from verticapy.learn.neighbors import LocalOutlierFactor
-from verticapy.learn.linear_model import LogisticRegression
-from verticapy.learn.model_selection import lift_chart, prc_curve
-from verticapy.learn.decomposition import PCA
-from verticapy.learn.tree import DecisionTreeRegressor
-from verticapy.learn.linear_model import LinearRegression
-from verticapy.learn.model_selection import stepwise
-from verticapy.learn.svm import LinearSVC
-from verticapy.learn.cluster import KMeans
+from verticapy.machine_learning.model_selection import elbow
+from verticapy.machine_learning.vertica.ensemble import RandomForestClassifier
+from verticapy.machine_learning.vertica.neighbors import LocalOutlierFactor
+from verticapy.machine_learning.vertica.linear_model import LogisticRegression
+from verticapy.machine_learning.metrics import lift_chart, prc_curve
+from verticapy.machine_learning.vertica.decomposition import PCA
+from verticapy.machine_learning.vertica.tree import DecisionTreeRegressor
+from verticapy.machine_learning.vertica.linear_model import LinearRegression
+from verticapy.machine_learning.model_selection import stepwise
+from verticapy.machine_learning.vertica.svm import LinearSVC
+from verticapy.machine_learning.vertica.cluster import KMeans
 from vertica_highcharts.highcharts.highcharts import Highchart
 
 # Standard Python Modules

--- a/verticapy/tests_new/plotting/base_test_files.py
+++ b/verticapy/tests_new/plotting/base_test_files.py
@@ -17,6 +17,7 @@ permissions and limitations under the License.
 
 from abc import abstractmethod
 import pytest
+import numpy as np
 
 # Vertica
 from verticapy.learn.model_selection import elbow
@@ -75,6 +76,47 @@ def get_zaxis_label(obj):
         return obj.options["zAxis"].title.text
     return None
 
+def get_xaxis_data_type(obj):
+    """
+    Get x-axis data type for given plotting object
+    """
+    if isinstance(obj, plt.Axes):
+        # Need to figure out how to get the data type for Matplotlib
+        return None
+    if isinstance(obj, go.Figure):
+        return obj.data[0]['x'].dtype
+    if isinstance(obj, Highchart):
+        # Need to figure out how to get the data type for Highcharts
+        return None
+    return None
+
+def get_yaxis_data_type(obj):
+    """
+    Get y-axis data type for given plotting object
+    """
+    if isinstance(obj, plt.Axes):
+        # Need to figure out how to get the data type for Matplotlib
+        return None
+    if isinstance(obj, go.Figure):
+        return obj.data[0]['y'].dtype
+    if isinstance(obj, Highchart):
+        # Need to figure out how to get the data type for Highcharts
+        return None
+    return None
+
+def get_zaxis_data_type(obj):
+    """
+    Get y-axis data type for given plotting object
+    """
+    if isinstance(obj, plt.Axes):
+        # Need to figure out how to get the data type for Matplotlib
+        return None
+    if isinstance(obj, go.Figure):
+        return obj.data[0]['z'].dtype
+    if isinstance(obj, Highchart):
+        # Need to figure out how to get the data type for Highcharts
+        return None
+    return None
 
 def get_width(obj):
     """
@@ -1387,6 +1429,25 @@ class ScatterVDF2DPlot(BasicPlotTests):
             {"columns": [self.COL_NAME_1, self.COL_NAME_2]},
         )
 
+    def test_data_type_for_x_axis(self):
+        """
+        Test if data type for X axis is float
+        """
+        # Arrange
+        # Act
+        # Assert - checking if correct object created
+        assert np.issubdtype(get_xaxis_data_type(self.result), float), "Wrong data type for X axis"
+        
+    def test_data_type_for_y_axis(self):
+        """
+        Test if data type for Y axis is float
+        """
+        # Arrange
+        # Act
+        # Assert - checking if correct object created
+        assert np.issubdtype(get_yaxis_data_type(self.result), float), "Wrong data type for Y axis"
+
+
     @pytest.mark.parametrize("attributes", [["Z", 50, 2], [None, 1000, 4]])
     def test_properties_output_type_for_all_options(
         self,
@@ -1446,6 +1507,16 @@ class ScatterVDF3DPlot(BasicPlotTests):
                 "by": self.COL_NAME_4,
             },
         )
+
+    def test_data_type_for_z_axis(self):
+        """
+        Test if data type for Y axis is float
+        """
+        # Arrange
+        # Act
+        # Assert - checking if correct object created
+        assert np.issubdtype(get_yaxis_data_type(self.result), float), "Wrong data type for Y axis"
+
 
 
 class VDCSpiderPlot:


### PR DESCRIPTION
Previously, when using the "by" option, the data type for x-axis and y-axis became string. This caused the plot to be misleading as it was more of a categorial axis than numerical.

I fixed that.

+ I added a Unit Test to ensure this is caught in the future. 

Todo:

- Need similar unit tests for highcharts and matplotlib