### PR TITLE
Vertica version for model versioning

### DIFF
--- a/verticapy/_utils/_sql/_vertica_version.py
+++ b/verticapy/_utils/_sql/_vertica_version.py
@@ -63,7 +63,7 @@ MINIMUM_VERTICA_VERSION = {
     "RandomForestClassifier": [8, 1, 1],
     "RandomForestRegressor": [9, 0, 1],
     "read_file": [11, 1, 1],
-    "RegisteredModel" : [12, 0, 4],
+    "RegisteredModel": [12, 0, 4],
     "Ridge": [8, 0, 0],
     "RobustScaler": [8, 1, 0],
     "roc_curve": [8, 0, 0],

--- a/verticapy/_utils/_sql/_vertica_version.py
+++ b/verticapy/_utils/_sql/_vertica_version.py
@@ -63,6 +63,7 @@ MINIMUM_VERTICA_VERSION = {
     "RandomForestClassifier": [8, 1, 1],
     "RandomForestRegressor": [9, 0, 1],
     "read_file": [11, 1, 1],
+    "RegisteredModel" : [12, 0, 4],
     "Ridge": [8, 0, 0],
     "RobustScaler": [8, 1, 0],
     "roc_curve": [8, 0, 0],

--- a/verticapy/machine_learning/vertica/base.py
+++ b/verticapy/machine_learning/vertica/base.py
@@ -579,6 +579,7 @@ class VerticaModel(PlottingUtils):
             specific to your class of interest,
             please refer to that particular class.
         """
+        vertica_version(condition=[12, 0, 4])
         try:
             if not self._is_native:
                 raise RuntimeError("Only native models can be registered.")

--- a/verticapy/mlops/model_versioning/base.py
+++ b/verticapy/mlops/model_versioning/base.py
@@ -22,6 +22,7 @@ from verticapy.machine_learning.vertica.base import VerticaModel
 from verticapy.machine_learning.vertica.model_management import load_model
 from verticapy._utils._sql._collect import save_verticapy_logs
 from verticapy._utils._sql._sys import _executeSQL
+from verticapy._utils._sql._vertica_version import check_minimum_version
 
 from verticapy._typing import (
     NoneType,

--- a/verticapy/mlops/model_versioning/base.py
+++ b/verticapy/mlops/model_versioning/base.py
@@ -48,6 +48,7 @@ class RegisteredModel:
 
     @save_verticapy_logs
     def __init__(self, registered_name: str) -> None:
+        vertica_version(condition=[12, 0, 4])
         self.registered_name = registered_name
 
         # it raises an error if it cannot find any model with such a registered name

--- a/verticapy/mlops/model_versioning/base.py
+++ b/verticapy/mlops/model_versioning/base.py
@@ -46,9 +46,9 @@ class RegisteredModel:
         of models registered with this name.
     """
 
+    @check_minimum_version
     @save_verticapy_logs
     def __init__(self, registered_name: str) -> None:
-        vertica_version(condition=[12, 0, 4])
         self.registered_name = registered_name
 
         # it raises an error if it cannot find any model with such a registered name


### PR DESCRIPTION
The mode versioning was added to Vertica 12.0.4. I had forgotten to check the version of the database when I implemented its VerticaPy API.