### PR TITLE
added parm in pytest to get top 10 slow tests

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,7 @@ envlist = py39,py310,py311,py312
 
 [testenv]
 passenv = *
-commands = pytest {posargs}
+commands = pytest --durations=10 {posargs}
 deps = 
     -rrequirements-testing.txt
     !py312: tensorflow


### PR DESCRIPTION
Added parm in pytest to get top 10 slow running tests. This will help us in prioritizing new_test. We will target to fix slowest running test first (if possible). 