### PR TITLE
Added code to overwrite the tree when Nan values are present

### DIFF
--- a/verticapy/machine_learning/vertica/base.py
+++ b/verticapy/machine_learning/vertica/base.py
@@ -980,16 +980,16 @@ class VerticaModel(PlottingUtils):
         for param in self.parameters:
             if param == "class_weight":
                 if isinstance(self.parameters[param], (list, np.ndarray)):
-                    parameters["class_weights"] = (
-                        f"'{', '.join([str(p) for p in self.parameters[param]])}'"
-                    )
+                    parameters[
+                        "class_weights"
+                    ] = f"'{', '.join([str(p) for p in self.parameters[param]])}'"
                 else:
                     parameters["class_weights"] = f"'{self.parameters[param]}'"
 
             elif isinstance(self.parameters[param], (str, dict)):
-                parameters[self._map_to_vertica_param_name(param)] = (
-                    f"'{self.parameters[param]}'"
-                )
+                parameters[
+                    self._map_to_vertica_param_name(param)
+                ] = f"'{self.parameters[param]}'"
 
             else:
                 parameters[self._map_to_vertica_param_name(param)] = self.parameters[
@@ -2482,7 +2482,6 @@ class Tree:
         if self._model_type == "IsolationForest":
             tree.values["prediction"], n = [], len(tree.values["leaf_path_length"])
             for i in range(n):
-
                 # Check if any training_row_count is NaN
                 if not isinstance(
                     tree.values["training_row_count"][i], NoneType

--- a/verticapy/machine_learning/vertica/base.py
+++ b/verticapy/machine_learning/vertica/base.py
@@ -2482,11 +2482,16 @@ class Tree:
         if self._model_type == "IsolationForest":
             tree.values["prediction"], n = [], len(tree.values["leaf_path_length"])
             for i in range(n):
+                # Check if any training_row_count is NaN
                 if not isinstance(
                     tree.values["training_row_count"][i], NoneType
                 ) and np.isnan(tree.values["training_row_count"][i]):
+                    # Check if the node is root
                     if not (tree.values["node_depth"][i] == 0):
                         tree.values["training_row_count"][i] = 0
+                    else:
+                        # If ``training_row_count`` is nan and the node is root, then discard the tree.
+                        return None
                 if not isinstance(tree.values["leaf_path_length"][i], NoneType):
                     tree.values["prediction"] += [
                         [

--- a/verticapy/machine_learning/vertica/base.py
+++ b/verticapy/machine_learning/vertica/base.py
@@ -14,6 +14,7 @@ OR CONDITIONS OF ANY KIND, either express or implied.
 See the  License for the specific  language governing
 permissions and limitations under the License.
 """
+
 import copy
 import warnings
 from abc import abstractmethod
@@ -979,16 +980,16 @@ class VerticaModel(PlottingUtils):
         for param in self.parameters:
             if param == "class_weight":
                 if isinstance(self.parameters[param], (list, np.ndarray)):
-                    parameters[
-                        "class_weights"
-                    ] = f"'{', '.join([str(p) for p in self.parameters[param]])}'"
+                    parameters["class_weights"] = (
+                        f"'{', '.join([str(p) for p in self.parameters[param]])}'"
+                    )
                 else:
                     parameters["class_weights"] = f"'{self.parameters[param]}'"
 
             elif isinstance(self.parameters[param], (str, dict)):
-                parameters[
-                    self._map_to_vertica_param_name(param)
-                ] = f"'{self.parameters[param]}'"
+                parameters[self._map_to_vertica_param_name(param)] = (
+                    f"'{self.parameters[param]}'"
+                )
 
             else:
                 parameters[self._map_to_vertica_param_name(param)] = self.parameters[
@@ -2481,6 +2482,11 @@ class Tree:
         if self._model_type == "IsolationForest":
             tree.values["prediction"], n = [], len(tree.values["leaf_path_length"])
             for i in range(n):
+                if not isinstance(
+                    tree.values["training_row_count"][i], NoneType
+                ) and np.isnan(tree.values["training_row_count"][i]):
+                    if not (tree.values["node_depth"][i] == 0):
+                        tree.values["training_row_count"][i] = 0
                 if not isinstance(tree.values["leaf_path_length"][i], NoneType):
                     tree.values["prediction"] += [
                         [

--- a/verticapy/machine_learning/vertica/base.py
+++ b/verticapy/machine_learning/vertica/base.py
@@ -2482,6 +2482,7 @@ class Tree:
         if self._model_type == "IsolationForest":
             tree.values["prediction"], n = [], len(tree.values["leaf_path_length"])
             for i in range(n):
+
                 # Check if any training_row_count is NaN
                 if not isinstance(
                     tree.values["training_row_count"][i], NoneType

--- a/verticapy/machine_learning/vertica/ensemble.py
+++ b/verticapy/machine_learning/vertica/ensemble.py
@@ -14,6 +14,7 @@ OR CONDITIONS OF ANY KIND, either express or implied.
 See the  License for the specific  language governing
 permissions and limitations under the License.
 """
+
 import random
 from typing import Literal, Optional, Union
 import numpy as np
@@ -4236,19 +4237,20 @@ class IsolationForest(Clustering, Tree):
                 self.get_tree(i),
                 self.X,
             )
-            tree_d = {
-                "children_left": tree[0],
-                "children_right": tree[1],
-                "feature": tree[2],
-                "threshold": tree[3],
-                "value": tree[4],
-                "psy": self.psy_,
-            }
-            for idx in range(len(tree[5])):
-                if not tree[5][idx] and isinstance(tree_d["threshold"][idx], str):
-                    tree_d["threshold"][idx] = float(tree_d["threshold"][idx])
-            model = mm.BinaryTreeAnomaly(**tree_d)
-            trees += [model]
+            if tree:
+                tree_d = {
+                    "children_left": tree[0],
+                    "children_right": tree[1],
+                    "feature": tree[2],
+                    "threshold": tree[3],
+                    "value": tree[4],
+                    "psy": self.psy_,
+                }
+                for idx in range(len(tree[5])):
+                    if not tree[5][idx] and isinstance(tree_d["threshold"][idx], str):
+                        tree_d["threshold"][idx] = float(tree_d["threshold"][idx])
+                model = mm.BinaryTreeAnomaly(**tree_d)
+                trees += [model]
         self.trees_ = trees
 
     # I/O Methods.


### PR DESCRIPTION
Previously we would get ``nan`` values for training_row_count. That produced an error. 

Now such ``nan`` values from the server side will be treated as follows:

if traning_row_count== NaN:
    if not node.isRoot():
        set traning_row_count to 0
    else:
        discard the tree
