### PR TITLE
Revert unnecessary test changes

### DIFF
--- a/verticapy/tests/vDataFrame/test_vDF_utilities.py
+++ b/verticapy/tests/vDataFrame/test_vDF_utilities.py
@@ -21,9 +21,6 @@ import pytest
 # Standard Python Modules
 import os, pickle
 from math import ceil, floor
-import time
-
-from vertica_python.errors import CopyRejected
 
 # Other Modules
 import pandas
@@ -38,7 +35,6 @@ from verticapy import (
     read_json,
 )
 from verticapy.connection import current_cursor
-from verticapy.core.parsers.pandas import read_pandas
 import verticapy.stats as st
 from verticapy.datasets import load_titanic, load_cities, load_amazon, load_world
 from verticapy.sql.sys import current_session, username


### PR DESCRIPTION
## Remove changes

Commit 3aa0b697b25ad accidentally changed [verticapy/tests/vDataFrame/test_vDF_utilities.py](https://github.com/vertica/VerticaPy/compare/master...jslaunwhite-microfocus:VerticaPyFork:bugfix/fixup_accidental_test_changes?expand=1#diff-65ecb09eb383d217f8c0443e07ef52ef9c0dee915b2c780b7595b578c1e7375c). The accidental change caused a conflict with Vikash's PR.

Checked out file to 8addeab0, reverting the change of 3aa0b697b.