### PR TITLE
Queryprofiler import restriction for same target_schema and key_id combination

### DIFF
--- a/verticapy/performance/vertica/collection/collection_tables.py
+++ b/verticapy/performance/vertica/collection/collection_tables.py
@@ -714,6 +714,15 @@ class CollectionTable:
             file_name=file_name, table_type=self.table_type, exported_rows=pdf_rows
         )
 
+    def check_if_tables_already_exist(self) -> int:
+        # Check if a table already exists
+        return f"""
+        SELECT CASE WHEN COUNT(*) > 0 THEN 1 ELSE 0 END AS table_exists
+        FROM v_catalog.tables 
+        WHERE table_schema = '{self.schema}'
+        AND table_name = '{self.get_import_name_fq().split('.')[-1]}';
+        """
+
 
 def getAllCollectionTables(
     target_schema: str, key: str, version: BundleVersion

--- a/verticapy/performance/vertica/collection/profile_import.py
+++ b/verticapy/performance/vertica/collection/profile_import.py
@@ -236,6 +236,15 @@ class ProfileImport:
             target_schema=self.target_schema, key=self.key, version=self.bundle_version
         )
         for ctable in all_tables.values():
+            if (
+                _executeSQL(ctable.check_if_tables_already_exist(), method="fetchall")[
+                    0
+                ][0]
+                == 1
+            ):
+                raise ProfileImportError(
+                    f"Schema '{self.target_schema}' and Key ID '{self.key}' are already in the database. Risk of overwriting data."
+                )
             self.logger.info(f"Running create statements for {ctable.name}")
             table_sql = ctable.get_create_table_sql()
             proj_sql = ctable.get_create_projection_sql()


### PR DESCRIPTION
When the users import a queryprofiler object **from a file** and provide a schema and key combination that has already been used, it will now raise an error instead of overwriting/appending.
```
qprof = QueryProfiler.import_profile(target_schema=target_schema_val,
    key_id=key_val,
    filename=file_val,
    auto_initialize = False                                          
```        