### PR TITLE
Improving workflows

### DIFF
--- a/.github/workflows/black.yml
+++ b/.github/workflows/black.yml
@@ -9,7 +9,7 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: psf/black@stable
         with:
           options: "--check --diff --verbose"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -17,7 +17,7 @@ jobs:
       - name: Installing graphviz package
         run: sudo apt-get update && sudo apt-get install graphviz
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v4
         with:

--- a/.github/workflows/master-codecov.yml
+++ b/.github/workflows/master-codecov.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Installing graphviz package
         run: sudo apt-get update && sudo apt-get install graphviz
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v4
         with:

--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -12,9 +12,9 @@ jobs:
       matrix:
         python-version: ["3.9", "3.10", "3.11"]
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -5,7 +5,7 @@ name: Upload Python Package
 
 on:
   release:
-    types: [created]
+    types: [published]
   workflow_dispatch:
 
 jobs:
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Set up Python
       uses: actions/setup-python@v4
       with:


### PR DESCRIPTION
The main improvement in this PR is changing the type of release trigger in the python-publish.yml workflow to [published].
According to this page the [published] type covers a broader range of events.
https://docs.github.com/en/webhooks/webhook-events-and-payloads?actionType=published#release

created: A draft was saved, or a release or pre-release was published without previously being saved as a draft.
published: A release, pre-release, or draft of a release was published.

Besides, I update the checkout actions in all workflows to version 4.
