### PR TITLE
Bugfix for creating QueryProfiler object with transaction, key and schema.

### DIFF
--- a/verticapy/performance/vertica/qprof.py
+++ b/verticapy/performance/vertica/qprof.py
@@ -936,20 +936,22 @@ class QueryProfiler:
 
         # CHECKING key_id; CREATING ONE IF IT DOES NOT EXIST.
         if isinstance(key_id, NoneType) or (
-            not (isinstance(transactions, NoneType)) and not (overwrite)
+            not (isinstance(transactions, NoneType))
+            and not (overwrite)
+            and (
+                len(QprofUtility._get_set_of_tables_in_schema(target_schema, key_id))
+                > 0
+            )
         ):
-            if not (isinstance(key_id, NoneType)) and (
-                not (isinstance(transactions, NoneType)) and not (overwrite)
-            ):
-                warning_message = (
-                    f"Parameter 'transactions' is not None, "
-                    "'key_id' is defined and parameter 'overwrite' "
-                    "is set to False. It means you are trying to "
-                    "use a potential existing key to store new "
-                    "transactions. This operation is not yet "
-                    "supported. A new key will be then generated."
-                )
-                warnings.warn(warning_message, Warning)
+            warning_message = (
+                f"Parameter 'transactions' is not None, "
+                "'key_id' is defined and parameter 'overwrite' "
+                "is set to False. It means you are trying to "
+                "use a potential existing key to store new "
+                "transactions. This operation is not yet "
+                "supported. A new key will be then generated."
+            )
+            warnings.warn(warning_message, Warning)
             self.key_id = str(uuid.uuid1()).replace("-", "")
         else:
             if isinstance(key_id, int):

--- a/verticapy/performance/vertica/qprof_utility.py
+++ b/verticapy/performance/vertica/qprof_utility.py
@@ -15,7 +15,9 @@ See the  License for the specific  language governing
 permissions and limitations under the License.
 """
 import re
-from typing import Union
+from typing import Union, Set
+
+from verticapy._utils._sql._sys import _executeSQL
 
 
 class QprofUtility:
@@ -160,3 +162,18 @@ class QprofUtility:
             "median ascending",
             "median descending",
         ]
+
+    @staticmethod
+    def _get_set_of_tables_in_schema(target_schema: str, key: str) -> Set[str]:
+        result = _executeSQL(
+            f"""SELECT table_name FROM v_catalog.tables 
+                    WHERE 
+                        table_schema = '{target_schema}'
+                        and table_name ilike '%_{key}';
+                    """,
+            method="fetchall",
+        )
+        existing_tables = set()
+        for row in result:
+            existing_tables.add(row[0])
+        return existing_tables


### PR DESCRIPTION
Previously, the provided key would not be used unless ```overwrite``` parameter was turned to ```True```. Now it will check if such a table with the exact key and schema exists, if it doesn't then it will use the user provided key. 

+ Brought the function "_get_set_of_tables_in_schema" inside qprof_utility