### PR TITLE
Bugfix - Empty vDataFrame creation

### DIFF
--- a/verticapy/core/parsers/pandas.py
+++ b/verticapy/core/parsers/pandas.py
@@ -345,6 +345,12 @@ def read_pandas(
         if len(df.columns) == len(null_columns):
             names = ", ".join([f"NULL AS {quote_ident(col)}" for col in df.columns])
             q = " UNION ALL ".join([f"(SELECT {names})" for i in range(len(df))])
+            if q == '':
+                if len(df.columns) > 0:
+                    joins = ', '.join([f'NULL::VARCHAR(64000) AS {col}' for col in df.columns])
+                    q = f"""SELECT  {joins} LIMIT 0"""
+                else:
+                    raise ValueError("There are no columns or values. Invalid DataFrame.")
             return vDataFrame(q)
         if len(str_cols) > 0 or len(null_columns) > 0:
             tmp_df = df.copy()

--- a/verticapy/core/tablesample/base.py
+++ b/verticapy/core/tablesample/base.py
@@ -14,6 +14,7 @@ OR CONDITIONS OF ANY KIND, either express or implied.
 See the  License for the specific  language governing
 permissions and limitations under the License.
 """
+
 import collections
 import copy
 import decimal
@@ -1597,6 +1598,9 @@ class TableSample:
                 row += [f"{val} AS {column_str}"]
             sql += [f"(SELECT {', '.join(row)})"]
         sql = " UNION ALL ".join(sql)
+        if sql == "":
+            joins = ", ".join([f"NULL::VARCHAR(64000) AS {col}" for col in self.values])
+            sql = f"""SELECT  {joins} LIMIT 0"""
         return sql
 
     def to_vdf(self) -> "vDataFrame":

--- a/verticapy/core/vdataframe/_io.py
+++ b/verticapy/core/vdataframe/_io.py
@@ -14,6 +14,7 @@ OR CONDITIONS OF ANY KIND, either express or implied.
 See the  License for the specific  language governing
 permissions and limitations under the License.
 """
+
 import copy
 import decimal
 import pickle
@@ -1734,7 +1735,10 @@ class vDFInOut(vDFSystem):
         )
         column_names = [column[0] for column in current_cursor().description]
         df = pd.DataFrame(data)
-        df.columns = column_names
+        if not df.empty:
+            df.columns = column_names
+        else:
+            df.reindex(columns=column_names)
         return df
 
     @save_verticapy_logs


### PR DESCRIPTION
Now the users can create a vDataFrame from an empty pandas dataframe which has column names.

For example:
```
import pandas as pd
from verticapy import read_pandas

df = pd.DataFrame()
df = df.reindex(columns = ["col1", "col2"])
read_pandas(df)
```

This also fixes a bug for exporting profiles from QueryProfiler. Sometimes, there would be certain tables missing while profiling. This would result in an error while exporting. Now the profiles can be exported even with those missing tables.