### PR TITLE
Bugfix - Empty vDataFrame + export_profile

### DIFF
--- a/verticapy/core/parsers/pandas.py
+++ b/verticapy/core/parsers/pandas.py
@@ -345,6 +345,16 @@ def read_pandas(
         if len(df.columns) == len(null_columns):
             names = ", ".join([f"NULL AS {quote_ident(col)}" for col in df.columns])
             q = " UNION ALL ".join([f"(SELECT {names})" for i in range(len(df))])
+            if q == "":
+                if len(df.columns) > 0:
+                    joins = ", ".join(
+                        [f"NULL::VARCHAR(64000) AS {col}" for col in df.columns]
+                    )
+                    q = f"""SELECT  {joins} LIMIT 0"""
+                else:
+                    raise ValueError(
+                        "There are no columns or values. Invalid DataFrame."
+                    )
             return vDataFrame(q)
         if len(str_cols) > 0 or len(null_columns) > 0:
             tmp_df = df.copy()

--- a/verticapy/core/tablesample/base.py
+++ b/verticapy/core/tablesample/base.py
@@ -1597,6 +1597,9 @@ class TableSample:
                 row += [f"{val} AS {column_str}"]
             sql += [f"(SELECT {', '.join(row)})"]
         sql = " UNION ALL ".join(sql)
+        if sql == "":
+            joins = ", ".join([f"NULL::VARCHAR(64000) AS {col}" for col in self.values])
+            sql = f"""SELECT  {joins} LIMIT 0"""
         return sql
 
     def to_vdf(self) -> "vDataFrame":

--- a/verticapy/core/vdataframe/_io.py
+++ b/verticapy/core/vdataframe/_io.py
@@ -1734,7 +1734,10 @@ class vDFInOut(vDFSystem):
         )
         column_names = [column[0] for column in current_cursor().description]
         df = pd.DataFrame(data)
-        df.columns = column_names
+        if not df.empty:
+            df.columns = column_names
+        else:
+            df.reindex(columns=column_names)
         return df
 
     @save_verticapy_logs

--- a/verticapy/performance/vertica/collection/collection_tables.py
+++ b/verticapy/performance/vertica/collection/collection_tables.py
@@ -679,7 +679,10 @@ class CollectionTable:
         if len(adjustments) != 0:
             # copies the dataframe. in-place update is deprecated according
             # to the pandas docs
-            dataframe = dataframe.astype(adjustments)
+            if not dataframe.empty:
+                dataframe = dataframe.astype(adjustments)
+            else:
+                dataframe = dataframe.reindex(columns=list(adjustments))
         self.logger.info(f"Begin copy to table {self.get_import_name()}")
         vdf = read_pandas(
             df=dataframe,


### PR DESCRIPTION
Now the users can create a vDataFrame from an empty pandas dataframe which has column names.

For example:
```
import pandas as pd
from verticapy import read_pandas

df = pd.DataFrame()
df = df.reindex(columns = ["col1", "col2"])
read_pandas(df)
```
This also fixes a bug for exporting profiles from QueryProfiler. Sometimes, there would be certain tables missing while profiling. This would result in an error while exporting. Now the profiles can be exported even with those missing tables.