### PR TITLE
Updating ci/cd tools

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -8,7 +8,7 @@ on:
 jobs:
   build:
 
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     strategy:
       matrix:
         python-version: ["3.9", "3.10", "3.11", "3.12"]
@@ -25,10 +25,10 @@ jobs:
       - name: Set up a Vertica server
         timeout-minutes: 15
         run: |
-          docker pull vertica/vertica-ce:latest
+          docker pull opentext/vertica-ce:latest
           docker run -d -v /tmp:/tmp -p 5433:5433 -p 5444:5444 \
             --name vertica_docker \
-            vertica/vertica-ce
+            opentext/vertica-ce
           echo "Vertica startup ..."
           until docker exec vertica_docker test -f /data/vertica/VMart/agent_start.out; do \
             echo "..."; \

--- a/.github/workflows/master-codecov.yml
+++ b/.github/workflows/master-codecov.yml
@@ -6,7 +6,7 @@ on:
 jobs:
   codecov:
     name: Codecov Workflow
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     strategy:
       matrix:
         python-version: ["3.9", "3.10", "3.11", "3.12"]
@@ -23,10 +23,10 @@ jobs:
       - name: Set up a Vertica server
         timeout-minutes: 15
         run: |
-          docker pull vertica/vertica-ce:latest
+          docker pull opentext/vertica-ce:latest
           docker run -d -v /tmp:/tmp -p 5433:5433 -p 5444:5444 \
             --name vertica_docker \
-            vertica/vertica-ce
+            opentext/vertica-ce
           echo "Vertica startup ..."
           until docker exec vertica_docker test -f /data/vertica/VMart/agent_start.out; do \
             echo "..."; \


### PR DESCRIPTION
Apparently, the address for vertica-ce releases has changed from vertica directory to opentext directory after 24.1.
Also, we had fixed the Ubuntu version awhile ago to avoid a versioning problem for running our unit tests. I hope that the problem is resolved by now.