### PR TITLE
QueryProfiler Import - Bugfix - Small interval values

### DIFF
--- a/verticapy/jupyter/_javascript.py
+++ b/verticapy/jupyter/_javascript.py
@@ -220,6 +220,9 @@ def clean_data(data: ArrayLike) -> ArrayLike:
                         val = "{:,}".format(val)
                     except:
                         pass
+                if isinstance(val, bool) is False and not isinstance(val, NoneType):
+                    data[i][j] = val
+                    continue
                 if isinstance(val, bool):
                     val = (
                         "<center>&#9989;</center>"

--- a/verticapy/performance/vertica/collection/profile_import.py
+++ b/verticapy/performance/vertica/collection/profile_import.py
@@ -347,4 +347,8 @@ class ProfileImport:
                 self.logger.info(f"Skipping missing file {expected_file_path}")
                 continue
             pd_dataframe = pd.read_parquet(expected_file_path)
+            if "running_time" in pd_dataframe.columns:
+                pd_dataframe["running_time"] = pd.to_timedelta(
+                    pd_dataframe["running_time"], unit="s"
+                )
             ctable.copy_from_pandas_dataframe(pd_dataframe)

--- a/verticapy/performance/vertica/qprof.py
+++ b/verticapy/performance/vertica/qprof.py
@@ -2130,7 +2130,9 @@ class QueryProfiler:
                 "statement_id": [tr[1] for tr in self.transactions],
                 "request_label": copy.deepcopy(self.request_labels),
                 "request": copy.deepcopy(self.requests),
-                "qduration": [qd / 1000000 for qd in self.qdurations],
+                "qduration": [
+                    qd / 1000000 if qd is not None else None for qd in self.qdurations
+                ],
                 "start_timestamp": self.start_timestamp,
                 "end_timestamp": self.end_timestamp,
             },


### PR DESCRIPTION
When very small interval values were being parsed, there was a COPY error because of mismatch of data types.

This fixes that by making sure the runnning_time is the correct data type.

it should solve: https://jira.verticacorp.com/jira/browse/VER-95728

Aslo Fixed an idisplay bug.