### PR TITLE
Bugfix for display

### DIFF
--- a/verticapy/jupyter/_widgets.py
+++ b/verticapy/jupyter/_widgets.py
@@ -86,14 +86,14 @@ class Visualizer:
         if self.orientation == "v":
             settings = widgets.HBox(self.settings_wids)
         with self.settings_box:
-            print_message(settings)
+            print_message(settings, "display")
         with self.graph_box:
             self.graph_box.clear_output(wait=True)
-            print_message(graph)
+            print_message(graph, "display")
         if self.orientation == "v":
-            print_message(widgets.VBox([self.settings_box, self.graph_box]))
+            print_message(widgets.VBox([self.settings_box, self.graph_box]), "display")
             return
-        print_message(widgets.HBox([self.settings_box, self.graph_box]))
+        print_message(widgets.HBox([self.settings_box, self.graph_box]), "display")
 
     @staticmethod
     def _accordion(children: list, titles: list) -> widgets.Accordion:


### PR DESCRIPTION
In the previous PR, we switched display -> print_message. 
but the additional `display` option was skipped for some of the displays causing the QueryProfiler hindering the display of QueryProfiler tree