### PR TITLE
Bugfix: QueryProfiler Import - Exception for when missing values in one of the tables

### DIFF
--- a/verticapy/performance/vertica/collection/profile_import.py
+++ b/verticapy/performance/vertica/collection/profile_import.py
@@ -352,4 +352,9 @@ class ProfileImport:
                 pd_dataframe["running_time"] = pd.to_timedelta(
                     pd_dataframe["running_time"], unit="s"
                 )
-            ctable.copy_from_pandas_dataframe(pd_dataframe)
+            try:
+                ctable.copy_from_pandas_dataframe(pd_dataframe)
+            except Exception as e:
+                warning_message = f"Error loading the table {ctable.name}:"
+                print_message(warning_message + str(e), "warning")
+                self.logger.warning(warning_message + str(e))


### PR DESCRIPTION
Previously, if there was any empty table in the tar file, it would break the code. Now, it will try to create the table and print a warning if there was an issue.