### PR TITLE
Three tier drill down highcharts

### DIFF
--- a/verticapy/core/vdataframe/_plotting.py
+++ b/verticapy/core/vdataframe/_plotting.py
@@ -414,7 +414,7 @@ class vDFPlot(vDFMachineLearning):
 
         """
         columns = format_type(columns, dtype=list)
-        columns, of = self.format_colnames(columns, of, expected_nb_of_cols=[1, 2])
+        columns, of = self.format_colnames(columns, of, expected_nb_of_cols=[1, 2, 3])
         if not (isinstance(max_cardinality, Iterable)):
             max_cardinality = (max_cardinality, max_cardinality)
         if not (isinstance(h, Iterable)):

--- a/verticapy/plotting/_highcharts/bar.py
+++ b/verticapy/plotting/_highcharts/bar.py
@@ -208,25 +208,75 @@ class DrillDownBarChart(HighchartsBase):
         else:
             # Top-level data
             data = [
-                {'name': 'A', 'y': 2.0, 'drilldown': 'A'},
-                {'name': 'B', 'y': 4.0, 'drilldown': 'B'},
-                {'name': 'C', 'y': 1.0, 'drilldown': 'C'}
+                {'name': 'Asia',   'y': 4000000000, 'drilldown': 'Asia'},
+                {'name': 'Africa', 'y': 1300000000, 'drilldown': 'Africa'},
+                {'name': 'Europe', 'y': 800000000,  'drilldown': 'Europe'}
             ]
             chart.add_data_set(data, kind, colorByPoint=True)
 
-            # Define groups with additional level for X/Y
+            # First drilldown level: Countries for each continent
+            # For each country we list: [Continent, Country, Population]
             self.data['groups'][0] = [
-                ['B','C','A','B','A'],
-                ['F','M','M','M','F'],
-                ['3','1','1','1','1']
+                # Continent names (one per country)
+                ['Asia',   'Asia',   'Asia',
+                'Africa', 'Africa', 'Africa',
+                'Europe', 'Europe', 'Europe'],
+                # Country names
+                ['China',  'India',  'Indonesia',
+                'Nigeria','Ethiopia','Egypt',
+                'Germany','France', 'UK'],
+                # Population values (as strings)
+                ['1600000000', '1200000000', '1200000000',
+                '500000000',  '400000000',  '400000000',
+                '300000000',  '250000000',  '250000000']
             ]
             self.data['groups'][1] = [
-                # Category, Gender, Subcategory (X/Y), Value
-                ['A', 'A', 'A', 'A', 'B', 'B', 'B', 'B', 'C', 'C', 'C', 'C'],
-                ['F', 'F', 'M', 'M', 'F', 'F', 'M', 'M', 'F', 'F', 'M', 'M'],
-                ['X', 'Y', 'X', 'Y', 'X', 'Y', 'X', 'Y', 'X', 'Y', 'X', 'Y'],
-                ['2', '1', '3', '4', '5', '2', '1', '3', '4', '1', '2', '5']
+                # Continent repeated for each breakdown entry
+                ['Asia', 'Asia',    # China
+                'Asia', 'Asia',    # India
+                'Asia', 'Asia',    # Indonesia
+                'Africa', 'Africa',# Nigeria
+                'Africa', 'Africa',# Ethiopia
+                'Africa', 'Africa',# Egypt
+                'Europe', 'Europe',# Germany
+                'Europe', 'Europe',# France
+                'Europe', 'Europe'],# UK
+                # Country names (repeated for each breakdown)
+                ['China', 'China',
+                'India', 'India',
+                'Indonesia', 'Indonesia',
+                'Nigeria', 'Nigeria',
+                'Ethiopia', 'Ethiopia',
+                'Egypt', 'Egypt',
+                'Germany', 'Germany',
+                'France', 'France',
+                'UK', 'UK'],
+                # Breakdown labels (e.g. Urban and Rural)
+                ['Urban', 'Rural'] * 9,
+                # Population breakdown values (as strings; must sum to the country's total)
+                [
+                    # China: Total 1,600,000,000 → Urban 800M, Rural 800M
+                    '800000000', '800000000',
+                    # India: Total 1,200,000,000 → Urban 400M, Rural 800M
+                    '400000000', '800000000',
+                    # Indonesia: Total 1,200,000,000 → Urban 600M, Rural 600M
+                    '600000000', '600000000',
+                    # Nigeria: Total 500,000,000 → Urban 200M, Rural 300M
+                    '200000000', '300000000',
+                    # Ethiopia: Total 400,000,000 → Urban 150M, Rural 250M
+                    '150000000', '250000000',
+                    # Egypt: Total 400,000,000 → Urban 250M, Rural 150M
+                    '250000000', '150000000',
+                    # Germany: Total 300,000,000 → Urban 200M, Rural 100M
+                    '200000000', '100000000',
+                    # France: Total 250,000,000 → Urban 150M, Rural 100M
+                    '150000000', '100000000',
+                    # UK: Total 250,000,000 → Urban 160M, Rural 90000000
+                    '160000000', '90000000'
+                ]
             ]
+            chart.add_data_set(data, kind, colorByPoint=True)
+
 
             # First drilldown level
             drilldown_group = np.column_stack(self.data["groups"][0])

--- a/verticapy/plotting/_highcharts/bar.py
+++ b/verticapy/plotting/_highcharts/bar.py
@@ -180,25 +180,15 @@ class DrillDownBarChart(HighchartsBase):
         chart.set_dict_options(style_kwargs)
         chart.add_JSsource("https://code.highcharts.com/6/modules/drilldown.js")
         n_groups = len(self.data["groups"])
-        
         if n_groups < 3:
-            print("less than 3 groups")
             init_group = np.column_stack(self.data["groups"][1])
             data = []
             for row in init_group:
                 data += [
                     {"name": str(row[0]), "y": float(row[1]), "drilldown": str(row[0])}
                 ]
-            print("data: \n", data)
             chart.add_data_set(data, kind, colorByPoint=True)
-            print("SELF DATA ALL: \n", self.data)
-            print("self.data['groups'][0]:", self.data["groups"][0])
-            try:
-                print("self.data['groups'][1]:", self.data["groups"][1])
-            except:
-                pass
             drilldown_group = np.column_stack(self.data["groups"][0])
-            print("drilldown_group:", drilldown_group)
             uniques = np.unique(drilldown_group[:, 0])
             for c in uniques:
                 data = drilldown_group[drilldown_group[:, 0] == c].tolist()
@@ -206,80 +196,14 @@ class DrillDownBarChart(HighchartsBase):
                 print(f"data for each {c}:", data)
                 chart.add_drilldown_data_set(data, kind, str(c), name=str(c))
         else:
-            # Top-level data
-            data = [
-                {'name': 'Asia',   'y': 4000000000, 'drilldown': 'Asia'},
-                {'name': 'Africa', 'y': 1300000000, 'drilldown': 'Africa'},
-                {'name': 'Europe', 'y': 800000000,  'drilldown': 'Europe'}
-            ]
-            chart.add_data_set(data, kind, colorByPoint=True)
-
-            # First drilldown level: Countries for each continent
-            # For each country we list: [Continent, Country, Population]
-            self.data['groups'][0] = [
-                # Continent names (one per country)
-                ['Asia',   'Asia',   'Asia',
-                'Africa', 'Africa', 'Africa',
-                'Europe', 'Europe', 'Europe'],
-                # Country names
-                ['China',  'India',  'Indonesia',
-                'Nigeria','Ethiopia','Egypt',
-                'Germany','France', 'UK'],
-                # Population values (as strings)
-                ['1600000000', '1200000000', '1200000000',
-                '500000000',  '400000000',  '400000000',
-                '300000000',  '250000000',  '250000000']
-            ]
-            self.data['groups'][1] = [
-                # Continent repeated for each breakdown entry
-                ['Asia', 'Asia',    # China
-                'Asia', 'Asia',    # India
-                'Asia', 'Asia',    # Indonesia
-                'Africa', 'Africa',# Nigeria
-                'Africa', 'Africa',# Ethiopia
-                'Africa', 'Africa',# Egypt
-                'Europe', 'Europe',# Germany
-                'Europe', 'Europe',# France
-                'Europe', 'Europe'],# UK
-                # Country names (repeated for each breakdown)
-                ['China', 'China',
-                'India', 'India',
-                'Indonesia', 'Indonesia',
-                'Nigeria', 'Nigeria',
-                'Ethiopia', 'Ethiopia',
-                'Egypt', 'Egypt',
-                'Germany', 'Germany',
-                'France', 'France',
-                'UK', 'UK'],
-                # Breakdown labels (e.g. Urban and Rural)
-                ['Urban', 'Rural'] * 9,
-                # Population breakdown values (as strings; must sum to the country's total)
-                [
-                    # China: Total 1,600,000,000 → Urban 800M, Rural 800M
-                    '800000000', '800000000',
-                    # India: Total 1,200,000,000 → Urban 400M, Rural 800M
-                    '400000000', '800000000',
-                    # Indonesia: Total 1,200,000,000 → Urban 600M, Rural 600M
-                    '600000000', '600000000',
-                    # Nigeria: Total 500,000,000 → Urban 200M, Rural 300M
-                    '200000000', '300000000',
-                    # Ethiopia: Total 400,000,000 → Urban 150M, Rural 250M
-                    '150000000', '250000000',
-                    # Egypt: Total 400,000,000 → Urban 250M, Rural 150M
-                    '250000000', '150000000',
-                    # Germany: Total 300,000,000 → Urban 200M, Rural 100M
-                    '200000000', '100000000',
-                    # France: Total 250,000,000 → Urban 150M, Rural 100M
-                    '150000000', '100000000',
-                    # UK: Total 250,000,000 → Urban 160M, Rural 90000000
-                    '160000000', '90000000'
+            init_group = np.column_stack(self.data["groups"][-1])
+            data = []
+            for row in init_group:
+                data += [
+                    {"name": str(row[0]), "y": float(row[1]), "drilldown": str(row[0])}
                 ]
-            ]
             chart.add_data_set(data, kind, colorByPoint=True)
-
-
-            # First drilldown level
-            drilldown_group = np.column_stack(self.data["groups"][0])
+            drilldown_group = np.column_stack(self.data["groups"][1])
             uniques = np.unique(drilldown_group[:, 0])
             for c in uniques:
                 data = drilldown_group[drilldown_group[:, 0] == c].tolist()
@@ -290,9 +214,8 @@ class DrillDownBarChart(HighchartsBase):
                     'drilldown': f"{c}-{x[1]}"
                 } for x in data]
                 chart.add_drilldown_data_set(data_points, kind, str(c), name=str(c))
-
             # Second drilldown level
-            drilldown_level2 = np.column_stack(self.data["groups"][1])
+            drilldown_level2 = np.column_stack(self.data["groups"][0])
             unique_keys = np.unique(drilldown_level2[:, 0:2], axis=0)
             for key in unique_keys:
                 parent_id, x_axis_label = key[0], key[1]
@@ -301,6 +224,4 @@ class DrillDownBarChart(HighchartsBase):
                 data_subset = drilldown_level2[mask]
                 data = [{'name': str(row[2]), 'y': float(row[3])} for row in data_subset]
                 chart.add_drilldown_data_set(data, kind, drilldown_id, name=f"{x_axis_label}")
-
-                
         return chart

--- a/verticapy/plotting/_highcharts/bar.py
+++ b/verticapy/plotting/_highcharts/bar.py
@@ -180,6 +180,7 @@ class DrillDownBarChart(HighchartsBase):
         chart.set_dict_options(style_kwargs)
         chart.add_JSsource("https://code.highcharts.com/6/modules/drilldown.js")
         n_groups = len(self.data["groups"])
+        
         if n_groups < 3:
             init_group = np.column_stack(self.data["groups"][1])
             data = []
@@ -193,7 +194,6 @@ class DrillDownBarChart(HighchartsBase):
             for c in uniques:
                 data = drilldown_group[drilldown_group[:, 0] == c].tolist()
                 data = [(str(x[1]), float(x[2])) for x in data]
-                print(f"data for each {c}:", data)
                 chart.add_drilldown_data_set(data, kind, str(c), name=str(c))
         else:
             init_group = np.column_stack(self.data["groups"][-1])
@@ -214,6 +214,7 @@ class DrillDownBarChart(HighchartsBase):
                     'drilldown': f"{c}-{x[1]}"
                 } for x in data]
                 chart.add_drilldown_data_set(data_points, kind, str(c), name=str(c))
+
             # Second drilldown level
             drilldown_level2 = np.column_stack(self.data["groups"][0])
             unique_keys = np.unique(drilldown_level2[:, 0:2], axis=0)
@@ -224,4 +225,6 @@ class DrillDownBarChart(HighchartsBase):
                 data_subset = drilldown_level2[mask]
                 data = [{'name': str(row[2]), 'y': float(row[3])} for row in data_subset]
                 chart.add_drilldown_data_set(data, kind, drilldown_id, name=f"{x_axis_label}")
+
+                
         return chart

--- a/verticapy/plotting/_highcharts/bar.py
+++ b/verticapy/plotting/_highcharts/bar.py
@@ -180,7 +180,7 @@ class DrillDownBarChart(HighchartsBase):
         chart.set_dict_options(style_kwargs)
         chart.add_JSsource("https://code.highcharts.com/6/modules/drilldown.js")
         n_groups = len(self.data["groups"])
-        
+
         if n_groups < 3:
             init_group = np.column_stack(self.data["groups"][1])
             data = []
@@ -203,28 +203,32 @@ class DrillDownBarChart(HighchartsBase):
                     {"name": str(row[0]), "y": float(row[1]), "drilldown": str(row[0])}
                 ]
             chart.add_data_set(data, kind, colorByPoint=True)
+            # First drilldown level
             drilldown_group = np.column_stack(self.data["groups"][1])
             uniques = np.unique(drilldown_group[:, 0])
             for c in uniques:
                 data = drilldown_group[drilldown_group[:, 0] == c].tolist()
                 # Add drilldown key for next level
-                data_points = [{
-                    'name': str(x[1]), 
-                    'y': float(x[2]), 
-                    'drilldown': f"{c}-{x[1]}"
-                } for x in data]
+                data_points = [
+                    {"name": str(x[1]), "y": float(x[2]), "drilldown": f"{c}-{x[1]}"}
+                    for x in data
+                ]
                 chart.add_drilldown_data_set(data_points, kind, str(c), name=str(c))
-
             # Second drilldown level
             drilldown_level2 = np.column_stack(self.data["groups"][0])
             unique_keys = np.unique(drilldown_level2[:, 0:2], axis=0)
             for key in unique_keys:
                 parent_id, x_axis_label = key[0], key[1]
                 drilldown_id = f"{parent_id}-{x_axis_label}"
-                mask = (drilldown_level2[:, 0] == parent_id) & (drilldown_level2[:, 1] == x_axis_label)
+                mask = (drilldown_level2[:, 0] == parent_id) & (
+                    drilldown_level2[:, 1] == x_axis_label
+                )
                 data_subset = drilldown_level2[mask]
-                data = [{'name': str(row[2]), 'y': float(row[3])} for row in data_subset]
-                chart.add_drilldown_data_set(data, kind, drilldown_id, name=f"{x_axis_label}")
+                data = [
+                    {"name": str(row[2]), "y": float(row[3])} for row in data_subset
+                ]
+                chart.add_drilldown_data_set(
+                    data, kind, drilldown_id, name=f"{x_axis_label}"
+                )
 
-                
         return chart

--- a/verticapy/plotting/base.py
+++ b/verticapy/plotting/base.py
@@ -1976,7 +1976,8 @@ class PlottingBase(PlottingBaseSQL):
             "limit_over": limit_over,
         }
 
-            # ND AGG Graphics: BAR / PIE / DRILLDOWNS ...
+        # ND AGG Graphics: BAR / PIE / DRILLDOWNS ...
+
     def _compute_rollup(
         self,
         vdf: "vDataFrame",
@@ -1996,7 +1997,7 @@ class PlottingBase(PlottingBaseSQL):
         columns = format_type(columns, dtype=list)
         method, aggregate, aggregate_fun, is_standard = self._map_method(method, of)
         n = len(columns)
-        
+
         # Process h:
         if not isinstance(h, (tuple, list)):
             h = (h,) * n
@@ -2005,7 +2006,7 @@ class PlottingBase(PlottingBaseSQL):
                 h = tuple(list(h) + [None] * (n - len(h)))
         # Replace any None with a default value (e.g., 1)
         h = tuple(1 if (x is None) else x for x in h)
-        
+
         # Process max_cardinality similarly
         if not isinstance(max_cardinality, (tuple, list)):
             if max_cardinality is None:
@@ -2014,13 +2015,15 @@ class PlottingBase(PlottingBaseSQL):
                 max_cardinality = (max_cardinality,) * n
         else:
             if len(max_cardinality) < n:
-                max_cardinality = tuple(list(max_cardinality) + [6] * (n - len(max_cardinality)))
-        
+                max_cardinality = tuple(
+                    list(max_cardinality) + [6] * (n - len(max_cardinality))
+                )
+
         vdf_tmp = vdf.copy()
         for idx, column in enumerate(columns):
             vdf_tmp[column].discretize(h=h[idx])
             vdf_tmp[column].discretize(method="topk", k=max_cardinality[idx])
-        
+
         groups = []
         metric, desc = self.get_category_desc(categoryorder)
         for i in range(0, n):


### PR DESCRIPTION
In this PR I added the functionality for a three-tier drilldown. This was necessary to plot three-tier plots for query step time using qprof.get_qsteps().


Below is the sample syntax:

``` 
import verticapy as vp
data = vp.vDataFrame({
  "gender": ['M', 'M', 'M', 'F', 'F', 'F', 'F'],
  "age": [20, 22, 23, 19, 21, 27, 24],
  "grade": ['A','B','C','A','B','B', 'B'],
  "status": ["pass", "pass", "fail", "fail", "pass", "fail", "fail"],
  "score": [0.99, 0.71, 0.66, 0.92, 0.79, 0.71, 0.77],
  "salary": [21000, 22000, 10000, 32000, 17000, 23000, 12000],
})
vp.set_option("plotting_lib", "highcharts")
data.bar(["grade", "gender", "status"], kind = "drilldown")
```