### PR TITLE
Bugfix - Query Tree - Updating the JS libraries

### DIFF
--- a/verticapy/jupyter/html/index.html
+++ b/verticapy/jupyter/html/index.html
@@ -1,27 +1,27 @@
 <!DOCTYPE html>
 <html>
-<meta charset="utf-8">
 <head>
-    <link rel="modulepreload" href="https://d3js.org/d3.v5.min.js" >
-    
+    <meta charset="utf-8">
+    <title>Graphviz Viewer</title>
+    <link rel="modulepreload" href="https://cdn.jsdelivr.net/npm/d3@7.8.5/dist/d3.min.js">
 </head>
 <body>
     <div id="graph" style="text-align: center;"></div>
-    <script src="https://d3js.org/d3.v5.min.js" type="module"></script>
-    <script src="https://unpkg.com/@hpcc-js/wasm@0.3.11/dist/index.min.js"></script>
-    <script src="https://unpkg.com/d3-graphviz@3.0.5/build/d3-graphviz.js" onload="initializeGraphviz()"></script>
+    
+    <script src="https://cdn.jsdelivr.net/npm/d3@7.8.5/dist/d3.min.js"></script>
+    
+    <script src="https://cdn.jsdelivr.net/npm/@hpcc-js/wasm@2.15.0/dist/graphviz.umd.js"></script>
+    
+    <script src="https://cdn.jsdelivr.net/npm/d3-graphviz@5.1.0/build/d3-graphviz.js" onload="initializeGraphviz()"></script>
+    
     <script>
-
-
         function initializeGraphviz() {
             var dotSrc = [];
             // Now you can use d3-graphviz safely
             d3.select("#graph").graphviz()
+                .zoom(true)
                 .renderDot(dotSrc);
         }
-
-        // document.addEventListener('DOMContentLoaded', initializeGraphviz);
-
     </script>
 </body>
 </html>


### PR DESCRIPTION
Updated library versions for index.js

Suddenly the query tree stopped displaying. Upon investigation I found that the WASM link was giving a 404 error. Now it works after this change.