### PR TITLE
Bugfix - QueryProfilerInterface gave error when there was no queue time

### DIFF
--- a/verticapy/performance/vertica/qprof.py
+++ b/verticapy/performance/vertica/qprof.py
@@ -2533,6 +2533,135 @@ class QueryProfiler:
             return None
         return float(self.qduration / self._get_interval(unit))
 
+    # Step 2b: Query queue time
+    def get_queue_time(
+        self,
+        unit: Literal["s", "m", "h"] = "s",
+    ) -> float:
+        """
+        Returns the Query queue time if available.
+
+        Parameters
+        ----------
+        unit: str, optional
+            Time Unit.
+
+            - s:
+                second
+
+            - m:
+                minute
+
+            - h:
+                hour
+
+        Returns
+        -------
+        float
+            Query queue time.
+
+        Examples
+        --------
+        First, let's import the
+        :py:class:`~verticapy.performance.vertica.qprof.QueryProfiler`
+        object.
+
+        .. code-block:: python
+
+            from verticapy.performance.vertica import QueryProfiler
+
+        Then we can create a query:
+
+        .. code-block:: python
+
+            qprof = QueryProfiler(
+                "select transaction_id, statement_id, request, request_duration"
+                " from query_requests where start_timestamp > now() - interval'1 hour'"
+                " order by request_duration desc limit 10;"
+            )
+
+        We can get the execution time by:
+
+        .. ipython:: python
+
+            qprof.get_queue_time(unit = "s")
+
+        .. note::
+
+            For more details, please look at
+            :py:class:`~verticapy.performance.vertica.qprof.QueryProfiler`.
+        """
+        if isinstance(self.queue_time, NoneType):
+            return None
+        return float(self.queue_time / self._get_interval(unit))
+
+    # Step 2c: Query run time
+    def get_run_time(
+        self,
+        unit: Literal["s", "m", "h"] = "s",
+    ) -> float:
+        """
+        Returns the Query run time (duration minus queue time) if available.
+
+        Parameters
+        ----------
+        unit: str, optional
+            Time Unit.
+
+            - s:
+                second
+
+            - m:
+                minute
+
+            - h:
+                hour
+
+        Returns
+        -------
+        float
+            Query run time.
+
+        Examples
+        --------
+        First, let's import the
+        :py:class:`~verticapy.performance.vertica.qprof.QueryProfiler`
+        object.
+
+        .. code-block:: python
+
+            from verticapy.performance.vertica import QueryProfiler
+
+        Then we can create a query:
+
+        .. code-block:: python
+
+            qprof = QueryProfiler(
+                "select transaction_id, statement_id, request, request_duration"
+                " from query_requests where start_timestamp > now() - interval'1 hour'"
+                " order by request_duration desc limit 10;"
+            )
+
+        We can get the run time by:
+
+        .. ipython:: python
+
+            qprof.get_run_time(unit = "s")
+
+        .. note::
+
+            This returns ``None`` if either query duration or queue time
+            is not available.
+
+            For more details, please look at
+            :py:class:`~verticapy.performance.vertica.qprof.QueryProfiler`.
+        """
+        if isinstance(self.qduration, NoneType) or isinstance(self.queue_time, NoneType):
+            return None
+        return float(
+            (self.qduration - self.queue_time) / self._get_interval(unit)
+        )
+
     # Step 3: Query execution steps
     def get_qsteps(
         self,

--- a/verticapy/performance/vertica/qprof.py
+++ b/verticapy/performance/vertica/qprof.py
@@ -2593,7 +2593,14 @@ class QueryProfiler:
         """
         if isinstance(self.queue_time, NoneType):
             return None
-        return float(self.queue_time / self._get_interval(unit))
+        if unit.startswith("s"):
+            return float(self.queue_time)
+        elif unit.startswith("m"):
+            return float(self.queue_time / 60)
+        elif unit.startswith("h"):
+            return float(self.queue_time / 3600)
+        else:
+            raise ValueError("Incorrect parameter 'unit'.")
 
     # Step 2c: Query run time
     def get_run_time(
@@ -2656,11 +2663,22 @@ class QueryProfiler:
             For more details, please look at
             :py:class:`~verticapy.performance.vertica.qprof.QueryProfiler`.
         """
-        if isinstance(self.qduration, NoneType) or isinstance(self.queue_time, NoneType):
+        qd = self.get_qduration(unit="s")
+        qt = self.get_queue_time(unit="s")
+
+        if qd is None or qt is None:
             return None
-        return float(
-            (self.qduration - self.queue_time) / self._get_interval(unit)
-        )
+
+        run_time_sec = qd - qt
+
+        if unit.startswith("s"):
+            return float(run_time_sec)
+        elif unit.startswith("m"):
+            return float(run_time_sec / 60)
+        elif unit.startswith("h"):
+            return float(run_time_sec / 3600)
+        else:
+            raise ValueError(f"Incorrect unit: {unit}")
 
     # Step 3: Query execution steps
     def get_qsteps(

--- a/verticapy/performance/vertica/qprof_interface.py
+++ b/verticapy/performance/vertica/qprof_interface.py
@@ -119,17 +119,23 @@ class QueryProfilerInterface(QueryProfilerStats):
                 <div style="display: table; border-spacing: 0;">
                     <div style="display: table-row;">
                         <div style="display: table-cell; "><b>Completion Time:</b></div>
-                        <div style="display: table-cell; text-align: right; width: 70px;">{float(self.get_qduration()):.6f}</div>
+                        <div style="display: table-cell; text-align: right; width: 70px;">
+                            {f"{float(self.get_qduration()):.6f}" if self.get_qduration() is not None else "NULL"}
+                        </div>
                         <div style="display: table-cell; ">(seconds)</div>
                     </div>
                     <div style="display: table-row;">
                         <div style="display: table-cell; "><b>Queue Time:</b></div>
-                        <div style="display: table-cell; text-align: right; width: 70px;">{float(self.queue_time):.6f}</div>
+                        <div style="display: table-cell; text-align: right; width: 70px;">
+                            {f"{float(self.get_queue_time()):.6f}" if self.get_queue_time() is not None else "NULL"}
+                        </div>
                         <div style="display: table-cell; ">(seconds)</div>
                     </div>
                     <div style="display: table-row;">
                         <div style="display: table-cell; "><b>Run Time:</b></div>
-                        <div style="display: table-cell; text-align: right; width: 70px;">{(float(self.get_qduration()) - float(self.queue_time)):.6f}</div>
+                        <div style="display: table-cell; text-align: right; width: 70px;">
+                            {f"{float(self.get_run_time()):.6f}" if self.get_run_time() is not None else "NULL"}
+                        </div>
                         <div style="display: table-cell; ">(seconds)</div>
                     </div>
                 </div>
@@ -789,17 +795,23 @@ class QueryProfilerInterface(QueryProfilerStats):
                 <div style="display: table; border-spacing: 0;">
                     <div style="display: table-row;">
                         <div style="display: table-cell; "><b>Completion Time:</b></div>
-                        <div style="display: table-cell; text-align: right; width: 70px;">{float(self.get_qduration()):.6f}</div>
+                        <div style="display: table-cell; text-align: right; width: 70px;">
+                            {f"{float(self.get_qduration()):.6f}" if self.get_qduration() is not None else "NULL"}
+                        </div>
                         <div style="display: table-cell; ">(seconds)</div>
                     </div>
                     <div style="display: table-row;">
                         <div style="display: table-cell; "><b>Queue Time:</b></div>
-                        <div style="display: table-cell; text-align: right; width: 70px;">{float(self.queue_time):.6f}</div>
+                        <div style="display: table-cell; text-align: right; width: 70px;">
+                            {f"{float(self.get_queue_time()):.6f}" if self.get_queue_time() is not None else "NULL"}
+                        </div>
                         <div style="display: table-cell; ">(seconds)</div>
                     </div>
                     <div style="display: table-row;">
                         <div style="display: table-cell; "><b>Run Time:</b></div>
-                        <div style="display: table-cell; text-align: right; width: 70px;">{(float(self.get_qduration()) - float(self.queue_time)):.6f}</div>
+                        <div style="display: table-cell; text-align: right; width: 70px;">
+                            {f"{float(self.get_run_time()):.6f}" if self.get_run_time() is not None else "NULL"}
+                        </div>
                         <div style="display: table-cell; ">(seconds)</div>
                     </div>
                 </div>


### PR DESCRIPTION
i have created helper functions to process the queue_time and run_time values for the QueryProfiler object.

For the QueryProfilerInterface, I have added checks for cases when the values could be None. 

This will make the QueryProfilerInterface support older qprofs.