### PR TITLE
Bugfix - For ML fit functions, the input relation was modifying the user indents

### DIFF
--- a/verticapy/machine_learning/vertica/base.py
+++ b/verticapy/machine_learning/vertica/base.py
@@ -2351,7 +2351,7 @@ class Supervised(VerticaModel):
         if isinstance(input_relation, vDataFrame) or (id_column):
             tmp_view = True
             if isinstance(input_relation, vDataFrame):
-                self.input_relation = input_relation.current_relation()
+                self.input_relation = input_relation.current_relation(reindent=False)
             else:
                 self.input_relation = input_relation
             if self._is_native:
@@ -7834,7 +7834,7 @@ class Unsupervised(VerticaModel):
         if isinstance(input_relation, vDataFrame) or (id_column):
             tmp_view = True
             if isinstance(input_relation, vDataFrame):
-                self.input_relation = input_relation.current_relation()
+                self.input_relation = input_relation.current_relation(reindent=False)
             else:
                 self.input_relation = input_relation
             if self._model_type == "MCA":

--- a/verticapy/machine_learning/vertica/neighbors.py
+++ b/verticapy/machine_learning/vertica/neighbors.py
@@ -3198,7 +3198,7 @@ class LocalOutlierFactor(VerticaModel):
             self._is_already_stored(raise_error=True)
         self.key_columns = quote_ident(key_columns)
         if isinstance(input_relation, vDataFrame):
-            self.input_relation = input_relation.current_relation()
+            self.input_relation = input_relation.current_relation(reindent=False)
             if not X:
                 X = input_relation.numcol()
         else:

--- a/verticapy/machine_learning/vertica/preprocessing.py
+++ b/verticapy/machine_learning/vertica/preprocessing.py
@@ -1019,7 +1019,7 @@ class CountVectorizer(VerticaModel):
         if isinstance(input_relation, vDataFrame):
             if isinstance(X, NoneType):
                 X = input_relation.get_columns()
-            self.input_relation = input_relation.current_relation()
+            self.input_relation = input_relation.current_relation(reindent=False)
         else:
             if isinstance(X, NoneType):
                 X = vDataFrame(input_relation).get_columns()

--- a/verticapy/machine_learning/vertica/tsa/base.py
+++ b/verticapy/machine_learning/vertica/tsa/base.py
@@ -278,7 +278,7 @@ class TimeSeriesModelBase(VerticaModel):
         if isinstance(input_relation, vDataFrame) and self._is_native:
             tmp_view = True
             if isinstance(input_relation, vDataFrame):
-                self.input_relation = input_relation.current_relation()
+                self.input_relation = input_relation.current_relation(reindent=False)
             else:
                 self.input_relation = input_relation
             relation = gen_tmp_name(


### PR DESCRIPTION
This is based off a user issue in #1355 .

The user-provided SQL was being unnecessarily modified. We have switched that to False.