### PR TITLE
Bugfix - load_model for RF and XGB Classifiers

### DIFF
--- a/verticapy/machine_learning/vertica/ensemble.py
+++ b/verticapy/machine_learning/vertica/ensemble.py
@@ -3702,10 +3702,14 @@ class XGBClassifier(MulticlassClassifier, XGBoost):
                 except (MissingRelation, QueryError):
                     # If training data is not available, use default prior from initial_prediction
                     try:
-                        prior_values = self.get_vertica_attributes("initial_prediction")["value"]
+                        prior_values = self.get_vertica_attributes(
+                            "initial_prediction"
+                        )["value"]
                         if null_:
                             prior_values = prior_values[1:]
-                        prior = np.array(prior_values)[1] if len(prior_values) > 1 else 0.5
+                        prior = (
+                            np.array(prior_values)[1] if len(prior_values) > 1 else 0.5
+                        )
                     except:
                         prior = 0.5  # Default fallback
             else:
@@ -3751,6 +3755,7 @@ class XGBClassifier(MulticlassClassifier, XGBoost):
             model = mm.BinaryTreeClassifier(**tree_d)
             trees += [model]
         self.trees_ = trees
+
     # I/O Methods.
 
     def to_memmodel(self) -> mm.XGBClassifier:

--- a/verticapy/machine_learning/vertica/ensemble.py
+++ b/verticapy/machine_learning/vertica/ensemble.py
@@ -28,6 +28,7 @@ from verticapy._typing import (
     SQLColumns,
     SQLRelation,
 )
+from verticapy.errors import ModelError
 from verticapy._utils._gen import gen_name
 from verticapy._utils._sql._collect import save_verticapy_logs
 from verticapy._utils._sql._format import clean_query, format_type, quote_ident
@@ -2709,12 +2710,12 @@ class RandomForestClassifier(MulticlassClassifier, RandomForest):
                 if unique_values:
                     self.classes_ = np.array(sorted(unique_values))
                 else:
-                    raise ValueError(
+                    raise ModelError(
                         "Unable to determine classes: no valid values found in tree structure. "
                         "This may indicate a problem with the model or data."
                     )
             except Exception as e:
-                raise ValueError(
+                raise ModelError(
                     f"Failed to infer classes from model structure: {str(e)}. "
                     "This may indicate the model is corrupted or incompatible."
                 )


### PR DESCRIPTION
A customer pointed an issue in #1351 

When you load a `RFClassifier` model, it cannot predict the probabilities. 

The issue was that it was not able to get the classes.

I created a specific unit test to capture this. When I ran the test for all ML models, I found a similar issue with XGB. I have implemented a fix for `XGBClassifier` as well. 

Fixed #1357 