### PR TITLE
Bugfix - Validate path should return the path string

### DIFF
--- a/verticapy/connection/utils.py
+++ b/verticapy/connection/utils.py
@@ -196,3 +196,4 @@ def validate_path(path: str):
         raise ValueError(
             f"Cannot use path '{path}': directory is not owned by the current user."
         )
+    return path


### PR DESCRIPTION
Fix validate_path to return the validated path, preventing NoneType errors when using VERTICAPY_CONNECTION and ensuring correct connection file handling.

This was brought up in discussion: https://github.com/vertica/VerticaPy/discussions/1359 