### PR TITLE
Bugfix - Fixed search for multi-space literals

### DIFF
--- a/verticapy/_utils/_sql/_format.py
+++ b/verticapy/_utils/_sql/_format.py
@@ -707,6 +707,102 @@ Utils
 """
 
 
+def _normalize_query_whitespace(query: str) -> str:
+    """
+    Normalizes whitespace and strips ``--`` line comments from a
+    SQL query in a single pass, while preserving the exact content
+    of single-quoted string literals.
+
+    This guarantees that whitespace located inside string literals
+    (for example ``'Paul  John'`` with two spaces) is never altered,
+    which is essential for filters such as ``name = 'Paul  John'``
+    or ``name LIKE 'Paul   %'`` to behave like plain SQL.
+
+    The function:
+
+    - keeps the content of single-quoted literals verbatim (it also
+      understands the ``''`` escape sequence for an embedded quote);
+    - keeps ``/* ... */`` block comments (such as ``/*+LABEL(...)*/``)
+      but collapses whitespace inside them, matching the historical
+      behavior;
+    - removes ``--`` line comments outside of literals/block comments;
+    - converts tabs and newlines to spaces and collapses consecutive
+      spaces everywhere outside string literals.
+
+    Parameters
+    ----------
+    query: str
+        SQL Query.
+
+    Returns
+    -------
+    str
+        Query with normalized whitespace.
+    """
+    result = []
+    i = 0
+    n = len(query)
+    # States: "normal", "string" (single-quoted literal), "block" (/* ... */)
+    state = "normal"
+    while i < n:
+        c = query[i]
+        if state == "string":
+            # Preserve everything verbatim until the closing quote.
+            result.append(c)
+            if c == "'":
+                if i + 1 < n and query[i + 1] == "'":
+                    # Escaped quote '' -> keep both and stay in the literal.
+                    result.append("'")
+                    i += 2
+                    continue
+                state = "normal"
+            i += 1
+            continue
+        if state == "block":
+            # Keep the block comment, but collapse its internal whitespace.
+            if c in (" ", "\t", "\n"):
+                if not result or result[-1] != " ":
+                    result.append(" ")
+                i += 1
+                continue
+            result.append(c)
+            if c == "*" and i + 1 < n and query[i + 1] == "/":
+                result.append("/")
+                i += 2
+                state = "normal"
+            else:
+                i += 1
+            continue
+        # state == "normal"
+        if c == "'":
+            state = "string"
+            result.append(c)
+            i += 1
+            continue
+        if c == "/" and i + 1 < n and query[i + 1] == "*":
+            state = "block"
+            result.append("/")
+            result.append("*")
+            i += 2
+            continue
+        if c == "-" and i + 1 < n and query[i + 1] == "-":
+            # Skip a "--" line comment up to (but not including) the newline,
+            # which is normalized to a space on the next iteration.
+            j = i + 2
+            while j < n and query[j] != "\n":
+                j += 1
+            i = j
+            continue
+        if c in (" ", "\t", "\n"):
+            if not result or result[-1] != " ":
+                result.append(" ")
+            i += 1
+            continue
+        result.append(c)
+        i += 1
+    return "".join(result)
+
+
 def clean_query(query: SQLExpression) -> SQLExpression:
     """
     Cleans the input query by
@@ -753,9 +849,7 @@ def clean_query(query: SQLExpression) -> SQLExpression:
     if isinstance(query, list):
         return [clean_query(q) for q in query]
     else:
-        query = re.sub(r"--.+(\n|\Z)", "", query)
-        query = query.replace("\t", " ").replace("\n", " ")
-        query = re.sub(" +", " ", query)
+        query = _normalize_query_whitespace(query)
 
         while len(query) > 0 and query.endswith((";", " ")):
             query = query[0:-1]

--- a/verticapy/tests_new/conftest.py
+++ b/verticapy/tests_new/conftest.py
@@ -229,6 +229,26 @@ def dummy_pred_data_vd():
     yield verticapy.vDataFrame({"X": x_val, "Y": y_val, "Z": z_val, "Category": pred})
 
 
+@pytest.fixture(scope="session")
+def space_names_vd():
+    """
+    Create a dummy vDataFrame with string values that contain varying numbers of spaces,
+    used to test that search/filter preserves whitespace in string literals.
+    """
+    yield verticapy.vDataFrame(
+        {
+            "id": [1, 2, 3, 4, 5],
+            "name": [
+                "Paul  John",    # 2 spaces
+                "Paul  John",    # 2 spaces
+                "Paul John",     # 1 space
+                "Paul    Smith", # 4 spaces
+                "Paul  Brown",   # 2 spaces
+            ],
+        }
+    )
+
+
 @pytest.fixture(scope="module")
 def titanic_vd(schema_loader):
     """

--- a/verticapy/tests_new/core/vdataframe/test_filter.py
+++ b/verticapy/tests_new/core/vdataframe/test_filter.py
@@ -434,3 +434,13 @@ class TestFilter:
             ]
 
         assert len(vpy_res) == len(py_res)
+
+    def test_search_with_spaces_in_string(self, space_names_vd):
+        """
+        test function - search preserves multiple spaces in string literals
+        """
+        result_double = space_names_vd.search("name = 'Paul  John'")
+        result_single = space_names_vd.search("name = 'Paul John'")
+
+        assert result_double.shape()[0] == 2
+        assert result_single.shape()[0] == 1


### PR DESCRIPTION
Current behavior:

All spaces are 'cleaned' to make them single space.

```
import verticapy as vp

vdf = vp.vDataFrame(
    {
        "id": [1, 2, 3, 4, 5],
        "name": [
            "Paul  John",      # 2 spaces
            "Paul  John",      # 2 spaces
            "Paul John",       # 1 space
            "Paul    Smith",   # 4 spaces
            "Paul  Brown",     # 2 spaces
        ],
    }
)
vdf.to_db(
    name="space_test",
    relation_type="table",
    inplace=True,
)
print("\n=== search: name = 'Paul  John' (double space) ===")
result1 = vp.vDataFrame("space_test").search("name = 'Paul  John'")
print(result1)
print("Expected 2 rows, got:", result1.shape()[0])

print("\n=== search: name = 'Paul John' (single space) ===")
result2 = vp.vDataFrame("space_test").search("name = 'Paul John'")
print(result2)
print("Expected 1 row, got:", result2.shape()[0])

print("\n=== search: LIKE 'Paul  %' (double space) ===")
result3 = vp.vDataFrame("space_test").search("name LIKE 'Paul  %'")
print(result3)
print("Expected 4 rows, got:", result3.shape()[0])

print("\n=== search: LIKE 'Paul    %' (4 spaces) ===")
result4 = vp.vDataFrame("space_test").search("name LIKE 'Paul    %'")
print(result4)
print("Expected 1 row, got:", result4.shape()[0])
```

Output:

```
=== search: name = 'Paul  John' (double space) ===
None  id    name  
Rows: 0 | Columns: 2
Expected 2 rows, got: 3

=== search: name = 'Paul John' (single space) ===
None  id         name  
1     1    Paul John  
2     2    Paul John  
3     3    Paul John  
Rows: 1-3 | Columns: 2
Expected 1 row, got: 3

=== search: LIKE 'Paul  %' (double space) ===
None  id    name  
Rows: 0 | Columns: 2
Expected 4 rows, got: 5

=== search: LIKE 'Paul    %' (4 spaces) ===
None  id    name  
Rows: 0 | Columns: 2
Expected 1 row, got: 5
```

So all spaces are converted into a single space. 

I created a new function `_normalize_query_whitespace` that guarantees that whitespace located inside string literals (for example ``'Paul  John'`` with two spaces) is never altered.